### PR TITLE
Allow hyphen-characters within usernames

### DIFF
--- a/sshpiperd/workingdir.go
+++ b/sshpiperd/workingdir.go
@@ -29,9 +29,9 @@ var (
 )
 
 func init() {
-	// http://stackoverflow.com/questions/6949667/what-are-the-real-rules-for-linux-usernames-on-centos-6-and-rhel-6
-	// #NAME_REGEX="^[a-z][-a-z0-9_]*\$"
-	usernameRule, _ = regexp.Compile("^[a-z_][a-z0-9_]{0,30}$")
+	// Base username validation on Debians default: https://sources.debian.net/src/adduser/3.113%2Bnmu3/adduser.conf/#L85
+	// -> NAME_REGEX="^[a-z][-a-z0-9_]*\$"
+	usernameRule, _ = regexp.Compile("^[a-z_][-a-z0-9_]{0,30}$")
 }
 
 func userSpecFile(user, file string) string {

--- a/sshpiperd/workingdir.go
+++ b/sshpiperd/workingdir.go
@@ -31,7 +31,8 @@ var (
 func init() {
 	// Base username validation on Debians default: https://sources.debian.net/src/adduser/3.113%2Bnmu3/adduser.conf/#L85
 	// -> NAME_REGEX="^[a-z][-a-z0-9_]*\$"
-	usernameRule, _ = regexp.Compile("^[a-z_][-a-z0-9_]{0,30}$")
+	// The length is limited to 32 characters. See man 8 useradd: https://linux.die.net/man/8/useradd
+	usernameRule, _ = regexp.Compile("^[a-z_][-a-z0-9_]{0,31}$")
 }
 
 func userSpecFile(user, file string) string {


### PR DESCRIPTION
This allows usernames like `ssh-test`.

To clarify: Hyphens are generally allowed, as long as they are not the first character. Take a look at the [debian restrictions](http://sources.debian.net/src/adduser/3.113%2Bnmu3/adduser.conf/#L85) for example.