### PR TITLE
fix git not found error on docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.15-alpine as builder
 RUN apk update \
         && apk upgrade \
         && apk add --no-cache \
-        ca-certificates \
+        ca-certificates git \
         && update-ca-certificates 2>/dev/null
 
 ADD . /go/src/github.com/tg123/sshpiper/


### PR DESCRIPTION
fixes the following error during docker build

/go/src/github.com/tg123/sshpiper/sshpiperd/ldflags.sh: line 1: git: not found