### PR TITLE
fix reference for downstream authorized keys

### DIFF
--- a/sshpiperd/upstream/database/model.go
+++ b/sshpiperd/upstream/database/model.go
@@ -76,7 +76,7 @@ type upstreamAuthorizedKey struct {
 	Key   keydata
 	KeyID int
 
-	DownstreamID int
+	UpstreamID int
 }
 
 type downstream struct {
@@ -101,7 +101,7 @@ type downstreamAuthorizedKey struct {
 	Key   keydata
 	KeyID int
 
-	UpstreamID int
+	DownstreamID int
 }
 
 type config struct {


### PR DESCRIPTION
Authorized keys for downstream were not queried/found. `pipe.AuthorizedKeys` was always empty even though they were set in the database.
I updated the mapping in model.go so `pipe.AuthorizedKeys` contains the referenced keys.