### PR TITLE
Print SSH upstream in brackets to distinguish port properly

### DIFF
--- a/sshpiperd/challenger/pome/upstream.go
+++ b/sshpiperd/challenger/pome/upstream.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/tg123/sshpiper/sshpiperd/upstream"
+	"github.com/tg123/sshpiper/sshpiperd/utils"
 )
 
 func (p *pome) authWithPipe(conn ssh.ConnMetadata, challengeContext ssh.AdditionalChallengeContext) (net.Conn, *ssh.AuthPipe, error) {
@@ -22,7 +23,7 @@ func (p *pome) authWithPipe(conn ssh.ConnMetadata, challengeContext ssh.Addition
 		return nil, nil, pipe.say("Not add Please check your configure")
 	}
 
-	addr := fmt.Sprintf("%v:%v", host, port)
+	addr := fmt.Sprintf("%v:%v", utils.FormatIPAddress(host), port)
 	c, err := net.Dial("tcp", addr)
 	if err != nil {
 		return nil, nil, pipe.say(fmt.Sprintf("Cannot connect to %v, reason: %v", addr, err))

--- a/sshpiperd/upstream/database/pipemgr.go
+++ b/sshpiperd/upstream/database/pipemgr.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jinzhu/gorm"
 
 	upstreamprovider "github.com/tg123/sshpiper/sshpiperd/upstream"
+	"github.com/tg123/sshpiper/sshpiperd/utils"
 )
 
 func (p *plugin) ListPipe() ([]upstreamprovider.Pipe, error) {
@@ -33,7 +34,7 @@ func (p *plugin) ListPipe() ([]upstreamprovider.Pipe, error) {
 		}
 
 		pipes = append(pipes, upstreamprovider.Pipe{
-			Host:             host,
+			Host:             utils.FormatIPAddress(host),
 			Port:             port,
 			Username:         d.Username,
 			UpstreamUsername: upuser,

--- a/sshpiperd/utils/common.go
+++ b/sshpiperd/utils/common.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+func FormatIPAddress(host string) string {
+	ip4 := net.ParseIP(host).To4()
+
+	if ip4 != nil || !strings.Contains(host, ":") {
+		return host
+	}
+
+	return fmt.Sprintf("[%s]", host)
+}


### PR DESCRIPTION
Before:
```
% sshpiperd pipe list
donatas -> root@2a02:4231:face:1001:1610:931c:2980:9d9d:22
```

After:
```
% sshpiperd pipe list
donatas -> root@[2a02:4231:face:1001:1610:931c:2980:9d9d]:22
```