### PR TITLE
fix: kubernetes watch and list in all namespaces

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -6,6 +6,7 @@ this plugin is inpsired by the [first version kubernetes plugin](https://github.
 
 ## Usage
 
+Start plugin with flag `--all-namespaces` or environment variable `SSHPIPERD_KUBERNETES_ALL_NAMESPACES=true` for cluster-wide usage, or it will listen to the namespace where it is in by default.
 
 ### Apply CRD definition
 
@@ -16,6 +17,7 @@ kubectl apply -f https://raw.githubusercontent.com/tg123/sshpiper/master/plugin/
 most parameters are the same as in [yaml](../yaml/)
 
 A full sample can be found [here](sample.yaml)
+
 
 ### Create Service
 

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -18,7 +18,6 @@ most parameters are the same as in [yaml](../yaml/)
 
 A full sample can be found [here](sample.yaml)
 
-
 ### Create Service
 
 ```

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -43,11 +43,6 @@ func newKubernetesPlugin() (*plugin, error) {
 		return nil, err
 	}
 
-	ns, _, err := kubeConfig.Namespace()
-	if err != nil {
-		return nil, err
-	}
-
 	k8sclient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
@@ -58,7 +53,7 @@ func newKubernetesPlugin() (*plugin, error) {
 		return nil, err
 	}
 
-	listWatcher := cache.NewListWatchFromClient(piperclient.SshpiperV1beta1().RESTClient(), "pipes", ns, fields.Everything())
+	listWatcher := cache.NewListWatchFromClient(piperclient.SshpiperV1beta1().RESTClient(), "pipes", metav1.NamespaceAll, fields.Everything())
 	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	lister := piperlister.NewPipeLister(store)
 	reflector := cache.NewReflector(listWatcher, &piperv1beta1.Pipe{}, store, 0)

--- a/plugin/kubernetes/main.go
+++ b/plugin/kubernetes/main.go
@@ -22,7 +22,6 @@ func main() {
 			if err != nil {
 				return nil, err
 			}
-			
 			return &libplugin.SshPiperPluginConfig{
 				NextAuthMethodsCallback: func(_ libplugin.ConnMetadata) ([]string, error) {
 					return plugin.supportedMethods()

--- a/plugin/kubernetes/main.go
+++ b/plugin/kubernetes/main.go
@@ -9,14 +9,21 @@ func main() {
 	libplugin.CreateAndRunPluginTemplate(&libplugin.PluginTemplate{
 		Name:  "kubernetes",
 		Usage: "sshpiperd kubernetes plugin",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:     "all-namespaces",
+				Usage:    "To watch all namespaces in the cluster",
+				EnvVars:  []string{"SSHPIPERD_KUBERNETES_ALL_NAMESPACES"},
+				Required: false,
+			},
+		},
 		CreateConfig: func(c *cli.Context) (*libplugin.SshPiperPluginConfig, error) {
-			plugin, err := newKubernetesPlugin()
+			plugin, err := newKubernetesPlugin(c.Bool("all-namespaces"))
 			if err != nil {
 				return nil, err
 			}
-
+			
 			return &libplugin.SshPiperPluginConfig{
-
 				NextAuthMethodsCallback: func(_ libplugin.ConnMetadata) ([]string, error) {
 					return plugin.supportedMethods()
 				},


### PR DESCRIPTION
It only watches and lists in the namespace that sshpiper being deployed. We should set this to all namespace for the cluster-wide usage. 