### PR TITLE
fix entrypoint keygen key type to Ed25519

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 if [ -z "$SSHPIPERD_SERVER_KEY" ]; then
     if [ ! -f /etc/ssh/ssh_host_ed25519_key ];then
-        ssh-keygen -t rsa -N '' -f /etc/ssh/ssh_host_ed25519_key
+        ssh-keygen -t ed25519 -N '' -f /etc/ssh/ssh_host_ed25519_key
     fi
 fi
 


### PR DESCRIPTION
Otherwise generates RSA key into file name used for Ed25519.

Related to #110 #111