### PR TITLE
build(docker): Non-root docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,17 @@ LABEL maintainer="Boshi Lian<farmer1992@gmail.com>"
 COPY --from=ep76/openssh-static:latest /usr/bin/ssh-keygen /bin/ssh-keygen
 RUN mkdir /etc/ssh/
 
-COPY --from=builder /sshpiperd/ /sshpiperd
+# Add user nobody with id 1
+ARG USERID=1000
+ARG GROUPID=1000
+RUN addgroup -g $GROUPID -S sshpiperd && adduser -u $USERID -S sshpiperd -G sshpiperd
+
+# Add execution rwx to user 1
+RUN chown -R $USERID:$GROUPID /etc/ssh/
+
+USER $USERID:$GROUPID
+
+COPY --from=builder --chown=$USERID /sshpiperd/ /sshpiperd
 EXPOSE 2222
 
 CMD ["/sshpiperd/entrypoint.sh"]


### PR DESCRIPTION
Close #154 

Build the image using non-root user (id=1000 by default)

You can change the userid/groupid using docker build args.

<details>
  <summary>Result</summary>
  
  ```bash
  shiishii@framework-gen12:~/dev/github.com/shiipou/sshpiper$ docker build -t shiipou/sshpiper .
[+] Building 10.8s (20/20) FINISHED
 => [internal] load .dockerignore                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                        0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                   0.0s
 => => transferring dockerfile: 1.02kB                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/ep76/openssh-static:latest                                                                                                                  0.7s
 => [internal] load metadata for docker.io/library/busybox:latest                                                                                                                      0.9s
 => [internal] load metadata for docker.io/library/golang:1.20-bullseye                                                                                                                0.9s
 => [builder 1/6] FROM docker.io/library/golang:1.20-bullseye@sha256:1cdb6c48f5d32b937b588151c7d9c61eafaded180c977d2f9de4a0747c7e198a                                                  0.0s
 => FROM docker.io/ep76/openssh-static:latest@sha256:2468dfcad44bd095f0d6803665a5ef7d85673cf4a26becb7d7f8d6cfd978a725                                                                  0.0s
 => [stage-1 1/6] FROM docker.io/library/busybox@sha256:560af6915bfc8d7630e50e212e08242d37b63bd5c1ccf9bd4acccf116e262d5b                                                               0.0s
 => [internal] load build context                                                                                                                                                      0.1s
 => => transferring context: 35.56kB                                                                                                                                                   0.1s
 => CACHED [stage-1 2/6] COPY --from=ep76/openssh-static:latest /usr/bin/ssh-keygen /bin/ssh-keygen                                                                                    0.0s
 => CACHED [stage-1 3/6] RUN mkdir /etc/ssh/                                                                                                                                           0.0s
 => [stage-1 4/6] RUN addgroup -g 1000 -S sshpiperd && adduser -u 1000 -S sshpiperd -G sshpiperd                                                                                       0.5s
 => CACHED [builder 2/6] RUN mkdir -p /sshpiperd/plugins                                                                                                                               0.0s
 => CACHED [builder 3/6] WORKDIR /src                                                                                                                                                  0.0s
 => [builder 4/6] RUN --mount=target=/src,type=bind,source=. --mount=type=cache,target=/root/.cache/go-build go build -o /sshpiperd -ldflags "-X main.mainver=devel" ./cmd/...         3.9s
 => [stage-1 5/6] RUN chown -R 1000:1000 /etc/ssh/                                                                                                                                     0.7s
 => [builder 5/6] RUN --mount=target=/src,type=bind,source=. --mount=type=cache,target=/root/.cache/go-build go build -o /sshpiperd/plugins -tags "" ./plugin/...                      4.3s
 => [builder 6/6] ADD entrypoint.sh /sshpiperd                                                                                                                                         0.0s
 => [stage-1 6/6] COPY --from=builder --chown=1000 /sshpiperd/ /sshpiperd                                                                                                              0.4s
 => exporting to image                                                                                                                                                                 0.4s
 => => exporting layers                                                                                                                                                                0.4s
 => => writing image sha256:d748acd050d2ba1986fbabd03eeeb0a0c91f194326d7b66ef989e603dea69e54                                                                                           0.0s
 => => naming to docker.io/shiipou/sshpiper                                                                                                                                            0.0s
shiishii@framework-gen12:~/dev/github.com/shiipou/sshpiper$ docker run -it --rm -p 2222:2222 shiipou/sshpiper sh
/ $ id
uid=1000(sshpiperd) gid=1000(sshpiperd) groups=1000(sshpiperd)
/ $
^[[Ashiishii@framework-gen12:~/dev/github.com/shiipou/sshpiper$ docker run -it --rm -p 2222:2222 shiipou/sshpiper
Generating public/private ed25519 key pair.
Your identification has been saved in /etc/ssh/ssh_host_ed25519_key
Your public key has been saved in /etc/ssh/ssh_host_ed25519_key.pub
The key fingerprint is:
SHA256:bpw71LIHwqqS5/XRM+vfO1Kvd03Aohc1ILvg9siXMDk sshpiperd@a6047ab92228
The key's randomart image is:
+--[ED25519 256]--+
|          . ..   |
|           o  o  |
|        . .  o . |
|       . o .o o  |
|     .  E... o . |
|      o*+Bo.o   .|
| .  ...o@++o . ..|
|o .... oo*o.. o o|
| +o.  ..++..+= . |
+----[SHA256]-----+
INFO[0000] starting sshpiperd version: devel, 6c81aee21, 2023-05-23T11:24:43Z, go1.20.4
INFO[0000] found host keys [/etc/ssh/ssh_host_ed25519_key]
INFO[0000] loading host key /etc/ssh/ssh_host_ed25519_key
INFO[0000] starting child process plugin: [/sshpiperd/plugins/workingdir]
INFO[0000] sshpiperd is listening on: [::]:2222
^C
  ```
  
</details>