### PR TITLE
automatic blocking of failing clients WIP

### DIFF
--- a/cmd/sshpiperd/blocklist.go
+++ b/cmd/sshpiperd/blocklist.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"net"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type blockList struct {
+	enabled  bool
+	maxRetry int
+	banTime  int
+	findTime int
+	ignoreIP string
+
+	ignoreIPNet *net.IPNet
+	events      []blockListEvent
+	blocked     map[string]int64
+}
+
+type blockListEvent struct {
+	host   string
+	time   int64
+	status bool
+}
+
+func newBlockList() (*blockList, error) {
+	// defaults
+	// TODO: ignoreIP multiple CIDRs
+	b := blockList{
+		enabled:  false,
+		maxRetry: 3,
+		banTime:  600,
+		findTime: 600,
+		ignoreIP: "127.0.0.1/8",
+
+		events:  []blockListEvent{},
+		blocked: map[string]int64{},
+	}
+
+	_, b.ignoreIPNet, _ = net.ParseCIDR(b.ignoreIP)
+
+	return &b, nil
+}
+
+func (b *blockList) SetIgnoreIP(s string) {
+	b.ignoreIP = s
+	// TODO: error handling?
+	_, b.ignoreIPNet, _ = net.ParseCIDR(b.ignoreIP)
+}
+
+func (b *blockList) addEvent(e blockListEvent) {
+	if !b.enabled {
+		return
+	}
+
+	// check if IP is not within ignored ranges
+	ip := net.ParseIP(e.host)
+	if b.ignoreIPNet.Contains(ip) {
+		log.Debugf("remote IP within ignored ranges for automatic blocking: %s", e.host)
+		return
+	}
+
+	if e.status {
+		// drop host events history on successful login
+		b.deleteHostEvents(e.host)
+	} else {
+		// cleanup historic data
+		b.garbageCollect()
+
+		// skip events if host already blocked
+		_, ok := b.blocked[e.host]
+
+		if !ok {
+			// append new event
+			b.events = append(b.events, e)
+
+			// count host failures
+			count := 0
+
+			for _, event := range b.events {
+				if event.host == e.host {
+					count++
+
+					// add host to blocklist and delete his events
+					if count >= b.maxRetry {
+						log.Infof("blocking remote host %s after %d failures", e.host, count)
+						b.blockHost(e.host)
+						break
+					}
+				}
+			}
+		}
+	}
+}
+
+func (b blockList) isBlocked(host string) bool {
+	b.garbageCollect()
+
+	_, ok := b.blocked[host]
+	log.Tracef("checking if remote IP %s is blocked: %t", host, ok)
+	return ok
+}
+
+func (b blockList) isBlockedAddr(addr net.Addr) bool {
+	s, _, _ := net.SplitHostPort(addr.String())
+	return b.isBlocked(s)
+}
+
+func (b *blockList) deleteHostEvents(host string) {
+	newEvents := []blockListEvent{}
+
+	for _, event := range b.events {
+		if event.host != host {
+			newEvents = append(newEvents, event)
+		}
+	}
+
+	b.events = newEvents
+}
+
+func (b *blockList) blockHost(host string) {
+	// add host to blocklist and delete his events
+	b.blocked[host] = time.Now().Unix() + int64(b.banTime)
+	b.deleteHostEvents(host)
+}
+
+func (b *blockList) garbageCollect() {
+	if !b.enabled {
+		return
+	}
+
+	now := time.Now().Unix()
+
+	// cleanup event list
+	thresholdTime := now - int64(b.findTime)
+
+	for index, event := range b.events {
+		// find first event which fits into our window and remove
+		// all previous events which are too old to consider
+		if event.time >= thresholdTime {
+			b.events = b.events[index:]
+			break
+		}
+
+		// we have reached end of slice without encountering
+		// event to preserve -> drop it all
+		if index == len(b.events)-1 {
+			b.events = []blockListEvent{}
+		}
+	}
+
+	// cleanup block list
+	for host, expire := range b.blocked {
+		if expire < now {
+			log.Infof("unblocking remote host %s", host)
+			delete(b.blocked, host)
+		}
+	}
+}
+
+func (b *blockList) dumpEvents() {
+	log.Debugf("---\nDump:\n")
+	for index, event := range b.events {
+		log.Debugf("%d: %s %d\n", index, event.host, event.time)
+	}
+	log.Debugf("---\n")
+}

--- a/cmd/sshpiperd/main.go
+++ b/cmd/sshpiperd/main.go
@@ -138,6 +138,36 @@ func main() {
 				Usage:   "filter out hostkeys-00@openssh.com which cause client side warnings",
 				EnvVars: []string{"SSHPIPERD_DROP_HOSTKEYS_MESSAGE"},
 			},
+			&cli.BoolFlag{
+				Name:    "ips-enable",
+				Value:   false,
+				Usage:   "enable built-in intrusion prevention system",
+				EnvVars: []string{"SSHPIPERD_IPS_ENABLE"},
+			},
+			&cli.IntFlag{
+				Name:    "ips-max-retry",
+				Value:   3,
+				Usage:   "maximum number of failed attempts before blocking",
+				EnvVars: []string{"SSHPIPERD_IPS_MAX_RETRY"},
+			},
+			&cli.IntFlag{
+				Name:    "ips-ban-time",
+				Value:   600,
+				Usage:   "blocking time of misbehaving client in seconds",
+				EnvVars: []string{"SSHPIPERD_IPS_BAN_TIME"},
+			},
+			&cli.IntFlag{
+				Name:    "ips-find-time",
+				Value:   600,
+				Usage:   "how old failure to consider in seconds relative to current time",
+				EnvVars: []string{"SSHPIPERD_IPS_FIND_TIME"},
+			},
+			&cli.StringFlag{
+				Name:    "ips-ignore-ip",
+				Value:   "127.0.0.1/8",
+				Usage:   "CIDR to ignore when automatic blocking",
+				EnvVars: []string{"SSHPIPERD_IPS_IGNORE_IP"},
+			},
 		},
 		Action: func(ctx *cli.Context) error {
 			level, err := log.ParseLevel(ctx.String("log-level"))


### PR DESCRIPTION
This is only a **draft of a quick and dirty PoC** to discuss about, but it does a job - blocks clients after a configurable amount of failures within a time window.

1. Do you think the approach of sending a connection status from go func. into a main loop is OK? (Yes, it's a simple success/failure status, without knowing why it failed, but still better than nothing).
2. Do you have idea about any part which you hate and require to be done completely different way?
3. Do you have any strong opinion about why you would not like to have this feature part of sshpiper?

Any comments welcome. I would rework / improve it later. Thanks.