### PR TITLE
allow override sshpiperd container arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-bullseye as builder
+FROM docker.io/golang:1.21-bullseye as builder
 
 ARG VER=devel
 ARG BUILDTAGS=""
@@ -12,7 +12,7 @@ RUN --mount=target=/src,type=bind,source=. --mount=type=cache,target=/root/.cach
 RUN --mount=target=/src,type=bind,source=. --mount=type=cache,target=/root/.cache/go-build if [ "$EXTERNAL" = "1" ]; then cp -r plugins /sshpiperd ; else go build -o /sshpiperd/plugins -tags "$BUILDTAGS" ./plugin/...; fi
 ADD entrypoint.sh /sshpiperd
 
-FROM busybox
+FROM docker.io/busybox
 LABEL maintainer="Boshi Lian<farmer1992@gmail.com>"
 
 RUN mkdir /etc/ssh/
@@ -30,4 +30,4 @@ USER $USERID:$GROUPID
 COPY --from=builder --chown=$USERID /sshpiperd/ /sshpiperd
 EXPOSE 2222
 
-CMD ["/sshpiperd/entrypoint.sh"]
+ENTRYPOINT ["/sshpiperd/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ set -eo pipefail
 PLUGIN=${PLUGIN:-workingdir}
 export SSHPIPERD_SERVER_KEY_GENERATE_MODE=${SSHPIPERD_SERVER_KEY_GENERATE_MODE:-notexist}
 
-/sshpiperd/sshpiperd /sshpiperd/plugins/$PLUGIN
+/sshpiperd/sshpiperd "${@:-/sshpiperd/plugins/$PLUGIN}"


### PR DESCRIPTION
To be able to still execute the entrypoint (and any logic which is/will be there), but completely override the sshpiperd arguments only. So, customizing the plugins usage should be easy.

Example:

```
# Default entrypoint sshpiperd arguments
$ docker run --rm -it localhost/sshpiperd:test
INFO[0000] starting sshpiperd version: devel, fc6c3e1e9, 2023-08-30T14:31:06Z, go1.21.0
INFO[0000] generating host key /etc/ssh/ssh_host_ed25519_key
INFO[0000] found host keys [/etc/ssh/ssh_host_ed25519_key]
INFO[0000] loading host key /etc/ssh/ssh_host_ed25519_key
INFO[0000] starting child process plugin: [/sshpiperd/plugins/workingdir]
INFO[0000] sshpiperd is listening on: [::]:2222
^C
```

```
# Completely custom sshpiperd arguments
$ docker run --rm -it localhost/sshpiperd:test /sshpiperd/plugins/workingdir -- /sshpiperd/plugins/failtoban
INFO[0000] starting sshpiperd version: devel, fc6c3e1e9, 2023-08-30T14:31:06Z, go1.21.0
INFO[0000] generating host key /etc/ssh/ssh_host_ed25519_key
INFO[0000] found host keys [/etc/ssh/ssh_host_ed25519_key]
INFO[0000] loading host key /etc/ssh/ssh_host_ed25519_key
INFO[0000] starting child process plugin: [/sshpiperd/plugins/workingdir]
INFO[0000] starting child process plugin: [/sshpiperd/plugins/failtoban]
INFO[0000] sshpiperd is listening on: [::]:2222
^C
```