### PR TITLE
Support for failtoban on Kubernetes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,15 @@ set -eo pipefail
 PLUGIN=${PLUGIN:-workingdir}
 export SSHPIPERD_SERVER_KEY_GENERATE_MODE=${SSHPIPERD_SERVER_KEY_GENERATE_MODE:-notexist}
 
-/sshpiperd/sshpiperd "${@:-/sshpiperd/plugins/$PLUGIN}"
+if [ $# -eq 0 ]; then
+    # $PLUGIN can contain a comma/space separated list of plugins
+    # to load (e.g., PLUGIN="kubernetes,failtoban")
+    PLUGINS=''
+    for P in $(echo "$PLUGIN" | tr ',;`$' ' '); do
+        PLUGINS="${PLUGINS}/sshpiperd/plugins/${P} -- "
+    done
+
+    exec /sshpiperd/sshpiperd ${PLUGINS}
+else
+    exec /sshpiperd/sshpiperd "${@}"
+fi

--- a/plugin/failtoban/main.go
+++ b/plugin/failtoban/main.go
@@ -1,5 +1,3 @@
-//go:build full || e2e
-
 package main
 
 import (


### PR DESCRIPTION
Changes:
- builds failtoban plugin even for non-full image
- extends container `PLUGIN` env.  to support list (for backward compatibility name left in singular)

Required by Helm chart change https://github.com/tg123/sshpiper-chart/pull/4