### PR TITLE
Make the log formatter configurable

### DIFF
--- a/cmd/sshpiperd/main.go
+++ b/cmd/sshpiperd/main.go
@@ -125,6 +125,12 @@ func main() {
 				EnvVars: []string{"SSHPIPERD_LOG_LEVEL"},
 			},
 			&cli.StringFlag{
+				Name:    "log-format",
+				Value:   "text",
+				Usage:   "log format, one of: text, json",
+				EnvVars: []string{"SSHPIPERD_LOG_FORMAT"},
+			},
+			&cli.StringFlag{
 				Name:    "typescript-log-dir",
 				Value:   "",
 				Usage:   "create typescript format screen recording and save into the directory see https://linux.die.net/man/1/script",
@@ -156,6 +162,10 @@ func main() {
 			}
 
 			log.SetLevel(level)
+
+			if ctx.String("log-format") == "json" {
+				log.SetFormatter(&log.JSONFormatter{})
+			}
 
 			log.Info("starting sshpiperd version: ", version())
 			d, err := newDaemon(ctx)

--- a/cmd/sshpiperd/main.go
+++ b/cmd/sshpiperd/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime/debug"
+	"slices"
 	"time"
 
 	"github.com/pires/go-proxyproto"
@@ -69,6 +70,11 @@ func createCmdPlugin(args []string) (*plugin.CmdPlugin, error) {
 	p.Name = exe
 
 	return p, nil
+}
+
+func isValidLogFormat(logFormat string) bool {
+	validFormats := []string{"text", "json"}
+	return slices.Contains(validFormats, logFormat)
 }
 
 func main() {
@@ -163,7 +169,11 @@ func main() {
 
 			log.SetLevel(level)
 
-			if ctx.String("log-format") == "json" {
+			logFormat := ctx.String("log-format")
+			if !isValidLogFormat(logFormat) {
+				return fmt.Errorf("not a valid log-format: %v", logFormat)
+			}
+			if logFormat == "json" {
 				log.SetFormatter(&log.JSONFormatter{})
 			}
 

--- a/libplugin/template.go
+++ b/libplugin/template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -11,6 +12,7 @@ type PluginTemplate struct {
 	Name         string
 	Usage        string
 	Flags        []cli.Flag
+	LogFormatter logrus.Formatter
 	CreateConfig func(c *cli.Context) (*SshPiperPluginConfig, error)
 }
 
@@ -42,7 +44,7 @@ func CreateAndRunPluginTemplate(t *PluginTemplate) {
 				return err
 			}
 
-			ConfigStdioLogrus(p, nil)
+			ConfigStdioLogrus(p, t.LogFormatter, nil)
 			return p.Serve()
 		},
 	}

--- a/libplugin/util.go
+++ b/libplugin/util.go
@@ -39,7 +39,7 @@ func AuthMethodFromName(n string) AuthMethod {
 	return -1
 }
 
-func ConfigStdioLogrus(p SshPiperPlugin, logger *logrus.Logger) {
+func ConfigStdioLogrus(p SshPiperPlugin, formatter logrus.Formatter, logger *logrus.Logger) {
 	if logger == nil {
 		logger = logrus.StandardLogger()
 	}
@@ -50,7 +50,11 @@ func ConfigStdioLogrus(p SshPiperPlugin, logger *logrus.Logger) {
 		logger.SetLevel(lv)
 
 		if tty {
-			logger.SetFormatter(&logrus.TextFormatter{ForceColors: true})
+			if formatter != nil {
+				logger.SetFormatter(formatter)
+			} else {
+				logger.SetFormatter(&logrus.TextFormatter{ForceColors: true})
+			}
 		}
 	})
 }


### PR DESCRIPTION
Apologies for not opening a feature request first. Just wanted to see how easy it was to implement support for JSON logs and it ended up being fairly simple.

Any chance this could be merged? I'm happy to make adjustments if you see any issues with the current implementation. The main goal is to be able to configure sshpiper to output logs in JSON format (by using `logrus`'s JSONFormatter instead of the default Text one).