### PR TITLE
Allow plugins to set a log formatter when TTY isn't allocated

### DIFF
--- a/libplugin/util.go
+++ b/libplugin/util.go
@@ -49,10 +49,12 @@ func ConfigStdioLogrus(p SshPiperPlugin, formatter logrus.Formatter, logger *log
 		lv, _ := logrus.ParseLevel(level)
 		logger.SetLevel(lv)
 
+		if formatter != nil {
+			logger.SetFormatter(formatter)
+		}
+
 		if tty {
-			if formatter != nil {
-				logger.SetFormatter(formatter)
-			} else {
+			if formatter == nil {
 				logger.SetFormatter(&logrus.TextFormatter{ForceColors: true})
 			}
 		}


### PR DESCRIPTION
For example, it's currently not possible to configure a different log formatter if sshpiper is running in a Docker container that has TTY disabled.