### PR TITLE
Fix timing format to correctly handle microsecond portion of time delta

### DIFF
--- a/cmd/sshpiperd/typescript.go
+++ b/cmd/sshpiperd/typescript.go
@@ -60,7 +60,7 @@ func (l *filePtyLogger) loggingTty(msg []byte) ([]byte, error) {
 		delta := now.Sub(l.oldtime)
 
 		// see term-utils/script.c
-		fmt.Fprintf(l.timing, "%v.%06v %v\n", int64(delta/time.Second), int64(delta/time.Microsecond), len(buf))
+		fmt.Fprintf(l.timing, "%v.%06v %v\n", int64(delta/time.Second), int64(delta%time.Second/time.Microsecond), len(buf))
 
 		l.oldtime = now
 


### PR DESCRIPTION
I noticed an issue in the timing calculation where the microsecond portion of the time delta was not being computed correctly. The previous implementation calculated the microseconds as `int64(delta/time.Microsecond)`, which leads to incorrect results because it includes the seconds in the microsecond portion.