### PR TITLE
support assciicast and logpath refactor

### DIFF
--- a/cmd/sshpiperd/asciicast.go
+++ b/cmd/sshpiperd/asciicast.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"time"
+)
+
+const (
+	msgChannelRequest = 98
+)
+
+func jsonEscape(i string) string {
+	b, err := json.Marshal(i)
+	if err != nil {
+		panic(err)
+	}
+	s := string(b)
+	return s[1 : len(s)-1]
+}
+
+func readString(buf *bytes.Reader) string {
+	var l uint32
+	binary.Read(buf, binary.BigEndian, &l)
+	s := make([]byte, l)
+	buf.Read(s)
+	return string(s)
+}
+
+type asciicastLogger struct {
+	cast       *os.File
+	starttime  time.Time
+	envs       map[string]string
+	initWidth  uint32
+	initHeight uint32
+}
+
+func newAsciicastLogger(logdir string) (*asciicastLogger, error) {
+	f, err := os.OpenFile(path.Join(logdir, "shell.cast"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &asciicastLogger{
+		cast:      f,
+		starttime: time.Now(),
+		envs:      make(map[string]string),
+	}, nil
+}
+
+func (l *asciicastLogger) uphook(msg []byte) ([]byte, error) {
+	if msg[0] == msgChannelData {
+		buf := msg[9:]
+		t := time.Since(l.starttime).Seconds()
+
+		_, err := fmt.Fprintf(l.cast, "[%v,\"o\",\"%s\"]\n", t, jsonEscape(string(buf)))
+
+		if err != nil {
+			return msg, err
+		}
+
+	}
+	return msg, nil
+}
+
+func (l *asciicastLogger) downhook(msg []byte) ([]byte, error) {
+	if msg[0] == msgChannelRequest {
+		t := time.Since(l.starttime).Seconds()
+		buf := bytes.NewReader(msg[5:])
+		reqType := readString(buf)
+
+		switch reqType {
+		case "pty-req":
+			buf.ReadByte()
+			term := readString(buf)
+			binary.Read(buf, binary.BigEndian, &l.initWidth)
+			binary.Read(buf, binary.BigEndian, &l.initHeight)
+			l.envs["TERM"] = term
+		case "env":
+			buf.ReadByte()
+			varName := readString(buf)
+			varValue := readString(buf)
+			l.envs[varName] = varValue
+		case "window-change":
+			buf.ReadByte()
+			var width, height uint32
+			binary.Read(buf, binary.BigEndian, &width)
+			binary.Read(buf, binary.BigEndian, &height)
+			_, err := fmt.Fprintf(l.cast, "[%v,\"r\", \"%vx%v\"]\n", t, width, height)
+			if err != nil {
+				return msg, err
+			}
+		case "shell", "exec":
+			jsonEnvs, err := json.Marshal(l.envs)
+
+			if err != nil {
+				return msg, err
+			}
+
+			_, err = fmt.Fprintf(
+				l.cast,
+				"{\"version\": 2, \"width\": %d, \"height\": %d, \"timestamp\": %d, \"env\": %v}\n",
+				l.initWidth,
+				l.initHeight,
+				l.starttime.Unix(),
+				string(jsonEnvs),
+			)
+
+			if err != nil {
+				return msg, err
+			}
+		}
+	}
+	return msg, nil
+}
+
+func (l *asciicastLogger) Close() (err error) {
+	l.cast.Close()
+	return nil
+}

--- a/cmd/sshpiperd/internal/plugin/grpc.go
+++ b/cmd/sshpiperd/internal/plugin/grpc.go
@@ -592,3 +592,13 @@ func DialCmd(cmd *exec.Cmd) (*CmdPlugin, error) {
 
 	return &CmdPlugin{*g, ch}, nil
 }
+
+func GetUniqueID(ctx ssh.ChallengeContext) string {
+	switch meta := ctx.(type) {
+	case *connMeta:
+		return meta.UniqId
+	case *chainConnMeta:
+		return meta.UniqId
+	}
+	panic("unknown challenge context")
+}

--- a/cmd/sshpiperd/main.go
+++ b/cmd/sshpiperd/main.go
@@ -143,6 +143,12 @@ func main() {
 				EnvVars: []string{"SSHPIPERD_TYPESCRIPT_LOG_DIR"},
 			},
 			&cli.StringFlag{
+				Name:    "asciicast-log-dir",
+				Value:   "",
+				Usage:   "create asciicast v2 format screen recording and save into the directory see https://docs.asciinema.org/manual/asciicast/v2",
+				EnvVars: []string{"SSHPIPERD_ASCIICAST_LOG_DIR"},
+			},
+			&cli.StringFlag{
 				Name:    "banner-text",
 				Value:   "",
 				Usage:   "display a banner before authentication, would be ignored if banner file was set",
@@ -257,6 +263,7 @@ func main() {
 			}
 
 			d.recorddir = ctx.String("typescript-log-dir")
+			d.asciicastdir = ctx.String("asciicast-log-dir")
 			d.filterHostkeysReqeust = ctx.Bool("drop-hostkeys-message")
 
 			go func() {

--- a/cmd/sshpiperd/main.go
+++ b/cmd/sshpiperd/main.go
@@ -137,16 +137,22 @@ func main() {
 				EnvVars: []string{"SSHPIPERD_LOG_FORMAT"},
 			},
 			&cli.StringFlag{
-				Name:    "typescript-log-dir",
+				Name:    "screen-recording-dir",
 				Value:   "",
-				Usage:   "create typescript format screen recording and save into the directory see https://linux.die.net/man/1/script",
-				EnvVars: []string{"SSHPIPERD_TYPESCRIPT_LOG_DIR"},
+				Usage:   "the directory to save screen recording files",
+				EnvVars: []string{"SSHPIPERD_SCREEN_RECORDING_DIR"},
 			},
 			&cli.StringFlag{
-				Name:    "asciicast-log-dir",
-				Value:   "",
-				Usage:   "create asciicast v2 format screen recording and save into the directory see https://docs.asciinema.org/manual/asciicast/v2",
-				EnvVars: []string{"SSHPIPERD_ASCIICAST_LOG_DIR"},
+				Name:    "screen-recording-format",
+				Value:   "asciicast",
+				Usage:   "the format of screen recording files, one of: typescript (https://linux.die.net/man/1/script), asciicast (https://docs.asciinema.org/manual/asciicast/v2)",
+				EnvVars: []string{"SSHPIPERD_SCREEN_RECORDING_FORMAT"},
+			},
+			&cli.BoolFlag{
+				Name:    "username-as-recorddir",
+				Value:   false,
+				Usage:   "use the username as the directory name for saving screen recording files",
+				EnvVars: []string{"SSHPIPERD_USERNAME_AS_RECORDDIR"},
 			},
 			&cli.StringFlag{
 				Name:    "banner-text",
@@ -262,9 +268,14 @@ func main() {
 				return err
 			}
 
-			d.recorddir = ctx.String("typescript-log-dir")
-			d.asciicastdir = ctx.String("asciicast-log-dir")
+			d.recorddir = ctx.String("screen-recording-dir")
+			d.recordfmt = ctx.String("screen-recording-format")
+			d.usernameAsRecorddir = ctx.Bool("username-as-recorddir")
 			d.filterHostkeysReqeust = ctx.Bool("drop-hostkeys-message")
+
+			if d.recordfmt != "typescript" && d.recordfmt != "asciicast" {
+				return fmt.Errorf("invalid screen recording format: %v", d.recordfmt)
+			}
 
 			go func() {
 				quit <- d.run()


### PR DESCRIPTION
Sometimes, a plugin needs to write logs to the database or specify the path for the screening recording before the recording process begins. To accommodate this, we can add a `FilePtyLoggerCallback` to the plugin. This allows the plugin to perform custom actions before the `FilePtyLogger` is created and specify a custom log destination.