### PR TITLE
support multiple YAML config files

### DIFF
--- a/plugin/yaml/main.go
+++ b/plugin/yaml/main.go
@@ -14,12 +14,12 @@ func main() {
 		Name:  "yaml",
 		Usage: "sshpiperd yaml plugin",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
+			&cli.StringSliceFlag{
 				Name:        "config",
-				Usage:       "path to yaml config file",
+				Usage:       "path to yaml config files, can be globs as well",
 				Required:    true,
 				EnvVars:     []string{"SSHPIPERD_YAML_CONFIG"},
-				Destination: &plugin.File,
+				Destination: &plugin.FileGlobs,
 			},
 			&cli.BoolFlag{
 				Name:        "no-check-perm",


### PR DESCRIPTION
This pull request introduces several significant changes to the `plugin/yaml` package, primarily focusing on enhancing configuration flexibility and refactoring code to improve maintainability. The most important changes include switching from single configuration files to multiple file globs, refactoring the `plugin` struct to `piperConfig`, and adjusting various methods to accommodate these updates.

Enhancements to configuration flexibility:

* [`plugin/yaml/main.go`](diffhunk://#diff-3f388169a11e75eafca4e384cf8f14498902df8ee8ed2b5ca3f5377e7e716392L17-R22): Changed the `config` flag from `cli.StringFlag` to `cli.StringSliceFlag` to allow multiple configuration files and globs. (`[plugin/yaml/main.goL17-R22](diffhunk://#diff-3f388169a11e75eafca4e384cf8f14498902df8ee8ed2b5ca3f5377e7e716392L17-R22)`)
* [`plugin/yaml/yaml.go`](diffhunk://#diff-697f3506c956389e7fe2fd7bd246bfe0d34cc71b1f93efb34fd3dff701a2c351L114-R153): Updated the `loadConfig` method to handle multiple configuration files using file globs. (`[plugin/yaml/yaml.goL114-R153](diffhunk://#diff-697f3506c956389e7fe2fd7bd246bfe0d34cc71b1f93efb34fd3dff701a2c351L114-R153)`)

Refactoring for maintainability:

* [`plugin/yaml/skel.go`](diffhunk://#diff-97a0681b4d5188f46cf52fe6e443dd13089c38b3a1c938abfb8760f102471169L12-R16): Replaced references to the `plugin` struct with `piperConfig` in various wrapper structs and methods to streamline code and improve clarity. (`[[1]](diffhunk://#diff-97a0681b4d5188f46cf52fe6e443dd13089c38b3a1c938abfb8760f102471169L12-R16)`, `[[2]](diffhunk://#diff-97a0681b4d5188f46cf52fe6e443dd13089c38b3a1c938abfb8760f102471169L31-R30)`, `[[3]](diffhunk://#diff-97a0681b4d5188f46cf52fe6e443dd13089c38b3a1c938abfb8760f102471169L42-R41)`, `[[4]](diffhunk://#diff-97a0681b4d5188f46cf52fe6e443dd13089c38b3a1c938abfb8760f102471169L73-R72)`, `[[5]](diffhunk://#diff-97a0681b4d5188f46cf52fe6e443dd13089c38b3a1c938abfb8760f102471169L104-R103)`, `[[6]](diffhunk://#diff-97a0681b4d5188f46cf52fe6e443dd13089c38b3a1c938abfb8760f102471169L118-R129)`, `[[7]](diffhunk://#diff-97a0681b4d5188f46cf52fe6e443dd13089c38b3a1c938abfb8760f102471169L147-R161)`)
* [`plugin/yaml/yaml.go`](diffhunk://#diff-697f3506c956389e7fe2fd7bd246bfe0d34cc71b1f93efb34fd3dff701a2c351L148-R166): Modified methods like `loadFileOrDecode` and `loadFileOrDecodeMany` to operate on `piperConfig` instead of `plugin`. (`[[1]](diffhunk://#diff-697f3506c956389e7fe2fd7bd246bfe0d34cc71b1f93efb34fd3dff701a2c351L148-R166)`, `[[2]](diffhunk://#diff-697f3506c956389e7fe2fd7bd246bfe0d34cc71b1f93efb34fd3dff701a2c351L161-R179)`)

Additional improvements:

* [`plugin/yaml/yaml.go`](diffhunk://#diff-697f3506c956389e7fe2fd7bd246bfe0d34cc71b1f93efb34fd3dff701a2c351R12): Added the `cli/v2` package to the list of imports to support the updated CLI flag functionality. (`[plugin/yaml/yaml.goR12](diffhunk://#diff-697f3506c956389e7fe2fd7bd246bfe0d34cc71b1f93efb34fd3dff701a2c351R12)`)
* [`plugin/yaml/yaml.go`](diffhunk://#diff-697f3506c956389e7fe2fd7bd246bfe0d34cc71b1f93efb34fd3dff701a2c351R80-R93): Introduced a `filename` field in the `piperConfig` struct to store the name of the configuration file, aiding in file operations. (`[plugin/yaml/yaml.goR80-R93](diffhunk://#diff-697f3506c956389e7fe2fd7bd246bfe0d34cc71b1f93efb34fd3dff701a2c351R80-R93)`)