### PR TITLE
lock e2e sshd version

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   host-password:
-    image: lscr.io/linuxserver/openssh-server:latest
+    image: lscr.io/linuxserver/openssh-server:9.7_p1-r4-ls184
     environment:
       - PASSWORD_ACCESS=true
       - USER_PASSWORD=pass
@@ -21,7 +21,7 @@ services:
       - netdistract
 
   host-publickey:
-    image: lscr.io/linuxserver/openssh-server:latest
+    image: lscr.io/linuxserver/openssh-server:9.7_p1-r4-ls184
     environment:
       - USER_NAME=user
       - LOG_STDOUT=true


### PR DESCRIPTION
due to https://man.openbsd.org/sshd_config.5#PerSourcePenalties
lock sshd version until better solution found