### PR TITLE
feat: Decide upstream based on user's unix group membership

### DIFF
--- a/e2e/e2eentry.sh
+++ b/e2e/e2eentry.sh
@@ -4,6 +4,9 @@ set -x
 # use entrypoint.sh to generate the ssh_host_ed25519_key
 PLUGIN="dummy_badname/" bash /sshpiperd/entrypoint.sh 2>/dev/null
 
+groupadd -f testgroup && \
+useradd -m -G testgroup testuser
+
 if [ "${SSHPIPERD_DEBUG}" == "1" ]; then
     echo "enter debug on hold mode"
     echo "run [docker exec -ti e2e_testrunner_1 bash] to run to attach"

--- a/e2e/e2eentry.sh
+++ b/e2e/e2eentry.sh
@@ -5,7 +5,7 @@ set -x
 PLUGIN="dummy_badname/" bash /sshpiperd/entrypoint.sh 2>/dev/null
 
 groupadd -f testgroup && \
-useradd -m -G testgroup testuser
+useradd -m -G testgroup testgroupuser
 
 if [ "${SSHPIPERD_DEBUG}" == "1" ]; then
     echo "enter debug on hold mode"

--- a/e2e/yaml_test.go
+++ b/e2e/yaml_test.go
@@ -540,7 +540,7 @@ func TestYaml(t *testing.T) {
 			"-p",
 			piperport,
 			"-l",
-			"testuser",
+			"testgroupuser",
 			"127.0.0.1",
 			fmt.Sprintf(`sh -c "echo -n %v > /shared/%v"`, randtext, targetfie),
 		)

--- a/libplugin/util.go
+++ b/libplugin/util.go
@@ -173,4 +173,3 @@ func VerifyHostKeyFromKnownHosts(knownhostsData io.Reader, hostname, netaddr str
 
 	return hostKeyCallback(hostname, addr, pub)
 }
-

--- a/libplugin/util.go
+++ b/libplugin/util.go
@@ -173,3 +173,4 @@ func VerifyHostKeyFromKnownHosts(knownhostsData io.Reader, hostname, netaddr str
 
 	return hostKeyCallback(hostname, addr, pub)
 }
+

--- a/plugin/yaml/schema.json
+++ b/plugin/yaml/schema.json
@@ -50,6 +50,9 @@
                 "username_regex_match": {
                     "type": "boolean"
                 },
+                "groupname": {
+                    "type": "string"
+                },
                 "authorized_keys": {
                     "oneOf": [
                         {

--- a/plugin/yaml/skel.go
+++ b/plugin/yaml/skel.go
@@ -3,9 +3,9 @@
 package main
 
 import (
+	"os/user"
 	"regexp"
 	"slices"
-	"os/user"
 
 	"github.com/tg123/sshpiper/libplugin"
 )
@@ -87,8 +87,8 @@ func (s *skelpipeToWrapper) KnownHosts(conn libplugin.ConnMetadata) ([]byte, err
 
 func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.SkelPipeTo, error) {
 	user := conn.User()
-  	userGroups, err := getUserGroups(user)
-  	if err != nil {
+	userGroups, err := getUserGroups(user)
+	if err != nil {
 		return nil, err
 	}
 
@@ -96,19 +96,19 @@ func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.
 
 	var matched bool
 	if s.from.Username != "" {
-    	  matched := s.from.Username == user
-	  if s.from.UsernameRegexMatch {
-	  	re, err := regexp.Compile(s.from.Username)
-	  	if err != nil {
-	  		return nil, err
-	  	}
+		matched := s.from.Username == user
+		if s.from.UsernameRegexMatch {
+			re, err := regexp.Compile(s.from.Username)
+			if err != nil {
+				return nil, err
+			}
 
-	  	matched = re.MatchString(user)
+			matched = re.MatchString(user)
 
-	  	if matched {
-	  		targetuser = re.ReplaceAllString(user, s.to.Username)
-	  	}
-	  }
+			if matched {
+				targetuser = re.ReplaceAllString(user, s.to.Username)
+			}
+		}
 	} else {
 		fromPipeGroup := s.from.Groupname
 		matched = slices.Contains(userGroups, fromPipeGroup)
@@ -197,24 +197,24 @@ func (p *plugin) listPipe(_ libplugin.ConnMetadata) ([]libplugin.SkelPipe, error
 }
 
 func getUserGroups(userName string) ([]string, error) {
-  usr, err := user.Lookup(userName)
-  if err != nil {
-      return nil, err
-  }
+	usr, err := user.Lookup(userName)
+	if err != nil {
+		return nil, err
+	}
 
-  groupIds, err := usr.GroupIds()
-  if err != nil {
-      return nil, err
-  }
+	groupIds, err := usr.GroupIds()
+	if err != nil {
+		return nil, err
+	}
 
-  var groups []string
-  for _, groupId := range groupIds {
-      grp, err := user.LookupGroupId(groupId)
-      if err != nil {
-          return nil, err
-      }
-      groups = append(groups, grp.Name)
-  }
+	var groups []string
+	for _, groupId := range groupIds {
+		grp, err := user.LookupGroupId(groupId)
+		if err != nil {
+			return nil, err
+		}
+		groups = append(groups, grp.Name)
+	}
 
-    return groups, nil
+	return groups, nil
 }

--- a/plugin/yaml/skel.go
+++ b/plugin/yaml/skel.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"regexp"
+	"slices"
+	"os/user"
 
 	"github.com/tg123/sshpiper/libplugin"
 )
@@ -85,25 +87,35 @@ func (s *skelpipeToWrapper) KnownHosts(conn libplugin.ConnMetadata) ([]byte, err
 
 func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.SkelPipeTo, error) {
 	user := conn.User()
+  	userGroups, err := getUserGroups(user)
+  	if err != nil {
+		return nil, err
+	}
 
-	matched := s.from.Username == user
 	targetuser := s.to.Username
+
+	var matched bool
+	if s.from.Username != "" {
+    	  matched := s.from.Username == user
+	  if s.from.UsernameRegexMatch {
+	  	re, err := regexp.Compile(s.from.Username)
+	  	if err != nil {
+	  		return nil, err
+	  	}
+
+	  	matched = re.MatchString(user)
+
+	  	if matched {
+	  		targetuser = re.ReplaceAllString(user, s.to.Username)
+	  	}
+	  }
+	} else {
+		fromPipeGroup := s.from.Groupname
+		matched = slices.Contains(userGroups, fromPipeGroup)
+	}
 
 	if targetuser == "" {
 		targetuser = user
-	}
-
-	if s.from.UsernameRegexMatch {
-		re, err := regexp.Compile(s.from.Username)
-		if err != nil {
-			return nil, err
-		}
-
-		matched = re.MatchString(user)
-
-		if matched {
-			targetuser = re.ReplaceAllString(user, s.to.Username)
-		}
 	}
 
 	if matched {
@@ -182,4 +194,27 @@ func (p *plugin) listPipe(_ libplugin.ConnMetadata) ([]libplugin.SkelPipe, error
 	}
 
 	return pipes, nil
+}
+
+func getUserGroups(userName string) ([]string, error) {
+  usr, err := user.Lookup(userName)
+  if err != nil {
+      return nil, err
+  }
+
+  groupIds, err := usr.GroupIds()
+  if err != nil {
+      return nil, err
+  }
+
+  var groups []string
+  for _, groupId := range groupIds {
+      grp, err := user.LookupGroupId(groupId)
+      if err != nil {
+          return nil, err
+      }
+      groups = append(groups, grp.Name)
+  }
+
+    return groups, nil
 }

--- a/plugin/yaml/skel.go
+++ b/plugin/yaml/skel.go
@@ -92,7 +92,7 @@ func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.
 
 	var matched bool
 	if s.from.Username != "" {
-		matched := s.from.Username == user
+		matched = s.from.Username == user
 		if s.from.UsernameRegexMatch {
 			re, err := regexp.Compile(s.from.Username)
 			if err != nil {

--- a/plugin/yaml/skel.go
+++ b/plugin/yaml/skel.go
@@ -87,10 +87,6 @@ func (s *skelpipeToWrapper) KnownHosts(conn libplugin.ConnMetadata) ([]byte, err
 
 func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.SkelPipeTo, error) {
 	user := conn.User()
-	userGroups, err := getUserGroups(user)
-	if err != nil {
-		return nil, err
-	}
 
 	targetuser := s.to.Username
 
@@ -109,7 +105,11 @@ func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.
 				targetuser = re.ReplaceAllString(user, s.to.Username)
 			}
 		}
-	} else {
+	} else if s.from.Groupname != "" {
+		userGroups, err := getUserGroups(user)
+		if err != nil {
+			return nil, err
+		}
 		fromPipeGroup := s.from.Groupname
 		matched = slices.Contains(userGroups, fromPipeGroup)
 	}

--- a/plugin/yaml/skel.go
+++ b/plugin/yaml/skel.go
@@ -109,7 +109,7 @@ func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.
 		}
 	} else if s.from.Groupname != "" {
 		// check user is known to the system before grouplookup
-		_, err := user.Lookup(username)
+		usr, err := user.Lookup(username)
 		if err != nil {
 			var unknownUser user.UnknownUserError
 			if errors.As(err, &unknownUser) {
@@ -119,7 +119,7 @@ func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.
 				return nil, err
 			}
 		}
-		userGroups, err := getUserGroups(username)
+		userGroups, err := getUserGroups(usr)
 		if err != nil {
 			return nil, err
 		}
@@ -209,12 +209,7 @@ func (p *plugin) listPipe(_ libplugin.ConnMetadata) ([]libplugin.SkelPipe, error
 	return pipes, nil
 }
 
-func getUserGroups(userName string) ([]string, error) {
-	usr, err := user.Lookup(userName)
-	if err != nil {
-		return nil, err
-	}
-
+func getUserGroups(usr *user.User) ([]string, error) {
 	groupIds, err := usr.GroupIds()
 	if err != nil {
 		return nil, err

--- a/plugin/yaml/skel.go
+++ b/plugin/yaml/skel.go
@@ -106,7 +106,10 @@ func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.
 			}
 		}
 	} else if s.from.Groupname != "" {
-		userGroups, _ := getUserGroups(user)
+		userGroups, err := getUserGroups(user)
+		if err != nil {
+			return nil, err
+		}
 		fromPipeGroup := s.from.Groupname
 		matched = slices.Contains(userGroups, fromPipeGroup)
 	}

--- a/plugin/yaml/skel.go
+++ b/plugin/yaml/skel.go
@@ -106,10 +106,7 @@ func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.
 			}
 		}
 	} else if s.from.Groupname != "" {
-		userGroups, err := getUserGroups(user)
-		if err != nil {
-			return nil, err
-		}
+		userGroups, _ := getUserGroups(user)
 		fromPipeGroup := s.from.Groupname
 		matched = slices.Contains(userGroups, fromPipeGroup)
 	}

--- a/plugin/yaml/yaml.go
+++ b/plugin/yaml/yaml.go
@@ -14,8 +14,8 @@ import (
 )
 
 type yamlPipeFrom struct {
- 	Username              string       `yaml:"username,omitempty"`
-	Groupname	            string       `yaml:"groupname,omitempty"`
+	Username              string       `yaml:"username,omitempty"`
+	Groupname             string       `yaml:"groupname,omitempty"`
 	UsernameRegexMatch    bool         `yaml:"username_regex_match,omitempty"`
 	AuthorizedKeys        listOrString `yaml:"authorized_keys,omitempty"`
 	AuthorizedKeysData    listOrString `yaml:"authorized_keys_data,omitempty"`

--- a/plugin/yaml/yaml.go
+++ b/plugin/yaml/yaml.go
@@ -14,7 +14,8 @@ import (
 )
 
 type yamlPipeFrom struct {
-	Username              string       `yaml:"username"`
+ 	Username              string       `yaml:"username,omitempty"`
+	Groupname	            string       `yaml:"groupname,omitempty"`
 	UsernameRegexMatch    bool         `yaml:"username_regex_match,omitempty"`
 	AuthorizedKeys        listOrString `yaml:"authorized_keys,omitempty"`
 	AuthorizedKeysData    listOrString `yaml:"authorized_keys_data,omitempty"`


### PR DESCRIPTION
Parse groupname defined in the yaml config file. Check if the user is part of that group and route them to the associated host specified in the config file for the yaml plugin.

Closes https://github.com/tg123/sshpiper/issues/535