### PR TITLE
Feat: fail2ban whitelist

### DIFF
--- a/e2e/failtoban_test.go
+++ b/e2e/failtoban_test.go
@@ -240,3 +240,235 @@ func TestFailtobanPipeCreateFail(t *testing.T) {
 		}
 	}
 }
+
+func TestFailtobanIgnoreIP(t *testing.T) {
+	piperaddr, piperport := nextAvailablePiperAddress()
+
+	piper, _, _, err := runCmd("/sshpiperd/sshpiperd",
+		"-p",
+		piperport,
+		"/sshpiperd/plugins/fixed",
+		"--target",
+		"host-password:2222",
+		"--",
+		"/sshpiperd/plugins/failtoban",
+		"--max-failures",
+		"3",
+		"--ignore-ip",
+		"127.0.0.1",
+	)
+
+	if err != nil {
+		t.Errorf("failed to run sshpiperd: %v", err)
+	}
+
+	defer killCmd(piper)
+
+	waitForEndpointReady(piperaddr)
+
+	{
+		randtext := uuid.New().String()
+		targetfie := uuid.New().String()
+
+		c, stdin, stdout, err := runCmd(
+			"ssh",
+			"-v",
+			"-o",
+			"StrictHostKeyChecking=no",
+			"-o",
+			"UserKnownHostsFile=/dev/null",
+			"-p",
+			piperport,
+			"-l",
+			"user",
+			"127.0.0.1",
+			fmt.Sprintf(`sh -c "echo -n %v > /shared/%v"`, randtext, targetfie),
+		)
+
+		if err != nil {
+			t.Errorf("failed to ssh to piper-workingdir, %v", err)
+		}
+
+		defer killCmd(c)
+
+		enterPassword(stdin, stdout, "pass")
+
+		time.Sleep(time.Second) // wait for file flush
+
+		checkSharedFileContent(t, targetfie, randtext)
+	}
+
+	// run 3 times with wrong password
+	{
+		c, stdin, stdout, err := runCmd(
+			"ssh",
+			"-v",
+			"-o",
+			"StrictHostKeyChecking=no",
+			"-o",
+			"UserKnownHostsFile=/dev/null",
+			"-p",
+			piperport,
+			"-l",
+			"user",
+			"127.0.0.1",
+		)
+		if err != nil {
+			t.Errorf("failed to ssh to piper-fixed, %v", err)
+		}
+
+		defer killCmd(c)
+
+		enterPassword(stdin, stdout, "wrongpass1")
+		enterPassword(stdin, stdout, "wrongpass2")
+		enterPassword(stdin, stdout, "wrongpass3")
+	}
+
+	{
+		randtext := uuid.New().String()
+		targetfie := uuid.New().String()
+
+		c, stdin, stdout, err := runCmd(
+			"ssh",
+			"-v",
+			"-o",
+			"StrictHostKeyChecking=no",
+			"-o",
+			"UserKnownHostsFile=/dev/null",
+			"-p",
+			piperport,
+			"-l",
+			"user",
+			"127.0.0.1",
+			fmt.Sprintf(`sh -c "echo -n %v > /shared/%v"`, randtext, targetfie),
+		)
+
+		if err != nil {
+			t.Errorf("failed to ssh to piper-workingdir, %v", err)
+		}
+
+		defer killCmd(c)
+
+		enterPassword(stdin, stdout, "pass")
+
+		time.Sleep(time.Second) // wait for file flush
+
+		checkSharedFileContent(t, targetfie, randtext)
+	}
+}
+
+func TestFailtobanIgnoreCIDR(t *testing.T) {
+	piperaddr, piperport := nextAvailablePiperAddress()
+
+	piper, _, _, err := runCmd("/sshpiperd/sshpiperd",
+		"-p",
+		piperport,
+		"/sshpiperd/plugins/fixed",
+		"--target",
+		"host-password:2222",
+		"--",
+		"/sshpiperd/plugins/failtoban",
+		"--max-failures",
+		"3",
+		"--ignore-ip",
+		"127.0.0.1/8",
+	)
+
+	if err != nil {
+		t.Errorf("failed to run sshpiperd: %v", err)
+	}
+
+	defer killCmd(piper)
+
+	waitForEndpointReady(piperaddr)
+
+	{
+		randtext := uuid.New().String()
+		targetfie := uuid.New().String()
+
+		c, stdin, stdout, err := runCmd(
+			"ssh",
+			"-v",
+			"-o",
+			"StrictHostKeyChecking=no",
+			"-o",
+			"UserKnownHostsFile=/dev/null",
+			"-p",
+			piperport,
+			"-l",
+			"user",
+			"127.0.0.1",
+			fmt.Sprintf(`sh -c "echo -n %v > /shared/%v"`, randtext, targetfie),
+		)
+
+		if err != nil {
+			t.Errorf("failed to ssh to piper-workingdir, %v", err)
+		}
+
+		defer killCmd(c)
+
+		enterPassword(stdin, stdout, "pass")
+
+		time.Sleep(time.Second) // wait for file flush
+
+		checkSharedFileContent(t, targetfie, randtext)
+	}
+
+	// run 3 times with wrong password
+	{
+		c, stdin, stdout, err := runCmd(
+			"ssh",
+			"-v",
+			"-o",
+			"StrictHostKeyChecking=no",
+			"-o",
+			"UserKnownHostsFile=/dev/null",
+			"-p",
+			piperport,
+			"-l",
+			"user",
+			"127.0.0.1",
+		)
+		if err != nil {
+			t.Errorf("failed to ssh to piper-fixed, %v", err)
+		}
+
+		defer killCmd(c)
+
+		enterPassword(stdin, stdout, "wrongpass1")
+		enterPassword(stdin, stdout, "wrongpass2")
+		enterPassword(stdin, stdout, "wrongpass3")
+	}
+
+	{
+		randtext := uuid.New().String()
+		targetfie := uuid.New().String()
+
+		c, stdin, stdout, err := runCmd(
+			"ssh",
+			"-v",
+			"-o",
+			"StrictHostKeyChecking=no",
+			"-o",
+			"UserKnownHostsFile=/dev/null",
+			"-p",
+			piperport,
+			"-l",
+			"user",
+			"127.0.0.1",
+			fmt.Sprintf(`sh -c "echo -n %v > /shared/%v"`, randtext, targetfie),
+		)
+
+		if err != nil {
+			t.Errorf("failed to ssh to piper-workingdir, %v", err)
+		}
+
+		defer killCmd(c)
+
+		enterPassword(stdin, stdout, "pass")
+
+		time.Sleep(time.Second) // wait for file flush
+
+		checkSharedFileContent(t, targetfie, randtext)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.31.0 // indirect
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
+	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=
 go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
+go4.org/netipx v0.0.0-20231129151722-fdeea329fbba h1:0b9z3AuHCjxk0x/opv64kcgZLBseWJUpBw5I82+2U4M=
+go4.org/netipx v0.0.0-20231129151722-fdeea329fbba/go.mod h1:PLyyIXexvUFg3Owu6p/WfdlivPbZJsZdgWZlrGope/Y=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=


### PR DESCRIPTION
In fail2ban, there's a way to ignore IP address or CIDR. 
I found missing this feature cause us to restart sshpiperd.service which kills all of the active connections.

While #519 introduced a way to reset the cache, it removes all entries in the cache.
