### PR TITLE
fix the username for group routing test case

### DIFF
--- a/e2e/yaml_test.go
+++ b/e2e/yaml_test.go
@@ -508,7 +508,7 @@ func TestYaml(t *testing.T) {
 			"-p",
 			piperport,
 			"-l",
-			"testuser",
+			"testgroupuser",
 			"-i",
 			path.Join(yamldir, "id_rsa_simple"),
 			"127.0.0.1",


### PR DESCRIPTION
Hi @tg123, quick fix for using the correct username in group-routing test case on L#511.

Could you please merge this ? 