### PR TITLE
fix: `entrypoint.sh` - Transfer PID1 to `sshpiperd`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ set -eo pipefail
 PLUGIN=${PLUGIN:-workingdir}
 export SSHPIPERD_SERVER_KEY_GENERATE_MODE=${SSHPIPERD_SERVER_KEY_GENERATE_MODE:-notexist}
 
-/sshpiperd/sshpiperd "${@:-/sshpiperd/plugins/$PLUGIN}"
+exec /sshpiperd/sshpiperd "${@:-/sshpiperd/plugins/$PLUGIN}"


### PR DESCRIPTION
This is a minor improvement and non-breaking change. [An alternative PR](https://github.com/tg123/sshpiper/pull/563) removes the need for `entrypoint.sh`.

---

This runs the command with `exec` which will hand-off to `sshpiperd` instead of running it as a command while retaining the shell process to wait until the command (daemon) terminates.

Since signals are not forwarded with the current entrypoint, stopping the container has a 10 second delay (_or whatever the equivalent default configured for waiting until sending a kill signal_).