### PR TITLE
Refactor: Revise `Dockerfile` - Remove `entrypoint.sh`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN \
   --mount=target=/src,type=bind,source=. \
   --mount=type=cache,target=/root/.cache/go-build \
   <<HEREDOC
+    # Create directories required for `cp` / `go build -o`:
     mkdir -p /sshpiperd/plugins
 
     if [ "${EXTERNAL}" = "1" ]; then
@@ -30,9 +31,9 @@ FROM docker.io/busybox AS sshpiperd
 ARG USERID=1000
 ARG GROUPID=1000
 RUN <<HEREDOC
-  # Add a non-root system (-S) user/group to run `sshpiperd` with:
-  addgroup -S sshpiperd -g "${GROUPID}"
-  adduser  -S sshpiperd -G -u "${USERID}" sshpiperd
+  # Add a non-root system (-S) user/group to run `sshpiperd` with (final arg is group/user name):
+  addgroup -S -g "${GROUPID}" sshpiperd 
+  adduser  -S -u "${USERID}" -G sshpiperd sshpiperd
 
   # Support `SSHPIPERD_SERVER_KEY_GENERATE_MODE=notexist` to create host key at `/etc/ssh`:
   mkdir /etc/ssh/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ RUN \
   --mount=target=/src,type=bind,source=. \
   --mount=type=cache,target=/root/.cache/go-build \
   <<HEREDOC
+    mkdir -p /sshpiperd/plugins
+
     if [ "${EXTERNAL}" = "1" ]; then
       cp sshpiperd /sshpiperd
-      mkdir -p /sshpiperd/plugins
       cp -r plugins /sshpiperd
     else
       go build -o /sshpiperd -ldflags "-X main.mainver=${VER}" ./cmd/...

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ ARG USERID=1000
 ARG GROUPID=1000
 RUN <<HEREDOC
   # Add a non-root system (-S) user/group to run `sshpiperd` with:
-  addgroup -g "${GROUPID}" -S sshpiperd
-  adduser -u "${USERID}" -S sshpiperd -G sshpiperd
+  addgroup -S sshpiperd -g "${GROUPID}"
+  adduser  -S sshpiperd -G -u "${USERID}" sshpiperd
 
   # Support `SSHPIPERD_SERVER_KEY_GENERATE_MODE=notexist` to create host key at `/etc/ssh`:
   mkdir /etc/ssh/

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,6 @@ COPY --from=builder --chown=${USERID} /sshpiperd/ /sshpiperd
 ENV SSHPIPERD_SERVER_KEY_GENERATE_MODE=notexist
 ENTRYPOINT ["/sshpiperd/sshpiperd"]
 CMD ["/sshpiperd/plugins/workingdir"]
-EXPOSE 2222
+
 USER ${USERID}:${GROUPID}
+EXPOSE 2222

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,47 @@
-FROM docker.io/golang:1.24-bookworm as builder
-
+FROM docker.io/golang:1.24-bookworm AS builder
 ARG VER=devel
-ARG BUILDTAGS=""
-ARG EXTERNAL="0"
+ARG BUILDTAGS
+ARG EXTERNAL=0
 
 ENV CGO_ENABLED=0
-
-RUN mkdir -p /sshpiperd/plugins
 WORKDIR /src
-RUN --mount=target=/src,type=bind,source=. --mount=type=cache,target=/root/.cache/go-build if [ "$EXTERNAL" = "1" ]; then cp sshpiperd /sshpiperd; else go build -o /sshpiperd -ldflags "-X main.mainver=$VER" ./cmd/... ; fi
-RUN --mount=target=/src,type=bind,source=. --mount=type=cache,target=/root/.cache/go-build if [ "$EXTERNAL" = "1" ]; then cp -r plugins /sshpiperd ; else go build -o /sshpiperd/plugins -tags "$BUILDTAGS" ./plugin/... ./e2e/testplugin/...; fi
+RUN \
+  --mount=target=/src,type=bind,source=. \
+  --mount=type=cache,target=/root/.cache/go-build \
+  <<HEREDOC
+    if [ "${EXTERNAL}" = "1" ]; then
+      cp sshpiperd /sshpiperd
+      mkdir -p /sshpiperd/plugins
+      cp -r plugins /sshpiperd
+    else
+      go build -o /sshpiperd -ldflags "-X main.mainver=${VER}" ./cmd/...
+      go build -o /sshpiperd/plugins -tags "${BUILDTAGS}" ./plugin/... ./e2e/testplugin/...
+    fi
+HEREDOC
 
-FROM builder as testrunner
+
+FROM builder AS testrunner
 COPY --from=farmer1992/openssh-static:V_9_8_P1 /usr/bin/ssh /usr/bin/ssh-9.8p1
 COPY --from=farmer1992/openssh-static:V_8_0_P1 /usr/bin/ssh /usr/bin/ssh-8.0p1
 
-FROM docker.io/busybox
-# LABEL maintainer="Boshi Lian<farmer1992@gmail.com>"
 
-RUN mkdir /etc/ssh/
-
-# Add user nobody with id 1
+FROM docker.io/busybox AS sshpiperd
 ARG USERID=1000
 ARG GROUPID=1000
-RUN addgroup -g $GROUPID -S sshpiperd && adduser -u $USERID -S sshpiperd -G sshpiperd
+RUN <<HEREDOC
+  # Add a non-root system (-S) user/group to run `sshpiperd` with:
+  addgroup -g "${GROUPID}" -S sshpiperd
+  adduser -u "${USERID}" -S sshpiperd -G sshpiperd
 
-# Add execution rwx to user 1
-RUN chown -R $USERID:$GROUPID /etc/ssh/
+  # Support `SSHPIPERD_SERVER_KEY_GENERATE_MODE=notexist` to create host key at `/etc/ssh`:
+  mkdir /etc/ssh/
+  chown -R "${USERID}:${GROUPID}" /etc/ssh/
+HEREDOC
+COPY --from=builder --chown=${USERID} /sshpiperd/ /sshpiperd
 
-USER $USERID:$GROUPID
-
-COPY --from=builder --chown=$USERID /sshpiperd/ /sshpiperd
-EXPOSE 2222
-
+# Runtime setup:
 ENV SSHPIPERD_SERVER_KEY_GENERATE_MODE=notexist
 ENTRYPOINT ["/sshpiperd/sshpiperd"]
 CMD ["/sshpiperd/plugins/workingdir"]
+EXPOSE 2222
+USER ${USERID}:${GROUPID}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,8 @@ RUN mkdir -p /sshpiperd/plugins
 WORKDIR /src
 RUN --mount=target=/src,type=bind,source=. --mount=type=cache,target=/root/.cache/go-build if [ "$EXTERNAL" = "1" ]; then cp sshpiperd /sshpiperd; else go build -o /sshpiperd -ldflags "-X main.mainver=$VER" ./cmd/... ; fi
 RUN --mount=target=/src,type=bind,source=. --mount=type=cache,target=/root/.cache/go-build if [ "$EXTERNAL" = "1" ]; then cp -r plugins /sshpiperd ; else go build -o /sshpiperd/plugins -tags "$BUILDTAGS" ./plugin/... ./e2e/testplugin/...; fi
-ADD entrypoint.sh /sshpiperd
 
 FROM builder as testrunner
-
 COPY --from=farmer1992/openssh-static:V_9_8_P1 /usr/bin/ssh /usr/bin/ssh-9.8p1
 COPY --from=farmer1992/openssh-static:V_8_0_P1 /usr/bin/ssh /usr/bin/ssh-8.0p1
 
@@ -35,4 +33,6 @@ USER $USERID:$GROUPID
 COPY --from=builder --chown=$USERID /sshpiperd/ /sshpiperd
 EXPOSE 2222
 
-ENTRYPOINT ["/sshpiperd/entrypoint.sh"]
+ENV SSHPIPERD_SERVER_KEY_GENERATE_MODE=notexist
+ENTRYPOINT ["/sshpiperd/sshpiperd"]
+CMD ["/sshpiperd/plugins/workingdir"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -eo pipefail
-
-PLUGIN=${PLUGIN:-workingdir}
-export SSHPIPERD_SERVER_KEY_GENERATE_MODE=${SSHPIPERD_SERVER_KEY_GENERATE_MODE:-notexist}
-
-/sshpiperd/sshpiperd "${@:-/sshpiperd/plugins/$PLUGIN}"


### PR DESCRIPTION
This PR removes the `entrypoint.sh` based on feedback detailed in https://github.com/tg123/sshpiper/issues/562

I've also used `HereDoc` syntax for multi-line `RUN` instructions. This makes the scripts more easier to read and bundle multiple commands into a single `RUN` without requiring `&&` and multiple trailing `\`.
- For the build stage the two separate layers have been combined based on the conditional logic, let me know if you'd rather have the plugins built in a separate layer.
- User docs regarding a `nobody` user with UID/GID of `1` seemed invalid, `/etc/ssh` related lines were co-located with a comment about the intent (which appears to be for host key generation).

I am not too familiar with the `sshpiperd` project. Presumably the `COPY` shouldn't need to do `--chown`? Just an executable bit via `chmod +x`? The plugins seem to be their own binary executables as well?

This PR unlike https://github.com/tg123/sshpiper/pull/561 would be a breaking change, notably because `PLUGIN` as an ENV would no longer have an effect. Everything else should work the same :+1:
