### PR TITLE
chore: `Dockerfile` - Use HereDoc syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ COPY --from=farmer1992/openssh-static:V_8_0_P1 /usr/bin/ssh /usr/bin/ssh-8.0p1
 
 FROM docker.io/busybox
 RUN <<HEREDOC
-  # Add a non-root system (-S) user/group to run `sshpiperd` with:
-  addgroup -S sshpiperd -g "${GROUPID}"
-  adduser  -S sshpiperd -G -u "${USERID}" sshpiperd
+  # Add a non-root system (-S) user/group to run `sshpiperd` with (final arg is group/user name):
+  addgroup -S -g "${GROUPID}" sshpiperd 
+  adduser  -S -u "${USERID}" -G sshpiperd sshpiperd
 
   # Support `SSHPIPERD_SERVER_KEY_GENERATE_MODE=notexist` to create host key at `/etc/ssh`:
   mkdir /etc/ssh/

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ COPY --from=farmer1992/openssh-static:V_9_8_P1 /usr/bin/ssh /usr/bin/ssh-9.8p1
 COPY --from=farmer1992/openssh-static:V_8_0_P1 /usr/bin/ssh /usr/bin/ssh-8.0p1
 
 FROM docker.io/busybox
+ARG USERID=1000
+ARG GROUPID=1000
 RUN <<HEREDOC
   # Add a non-root system (-S) user/group to run `sshpiperd` with (final arg is group/user name):
   addgroup -S -g "${GROUPID}" sshpiperd 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,47 @@
 FROM docker.io/golang:1.24-bookworm as builder
 
 ARG VER=devel
-ARG BUILDTAGS=""
-ARG EXTERNAL="0"
+ARG BUILDTAGS
+ARG EXTERNAL=0
 
 ENV CGO_ENABLED=0
 
-RUN mkdir -p /sshpiperd/plugins
 WORKDIR /src
-RUN --mount=target=/src,type=bind,source=. --mount=type=cache,target=/root/.cache/go-build if [ "$EXTERNAL" = "1" ]; then cp sshpiperd /sshpiperd; else go build -o /sshpiperd -ldflags "-X main.mainver=$VER" ./cmd/... ; fi
-RUN --mount=target=/src,type=bind,source=. --mount=type=cache,target=/root/.cache/go-build if [ "$EXTERNAL" = "1" ]; then cp -r plugins /sshpiperd ; else go build -o /sshpiperd/plugins -tags "$BUILDTAGS" ./plugin/... ./e2e/testplugin/...; fi
+RUN \
+  --mount=target=/src,type=bind,source=. \
+  --mount=type=cache,target=/root/.cache/go-build \
+  <<HEREDOC
+    # Create directories required for `cp` / `go build -o`:
+    mkdir -p /sshpiperd/plugins
+
+    if [ "${EXTERNAL}" = "1" ]; then
+      cp sshpiperd /sshpiperd
+      cp -r plugins /sshpiperd
+    else
+      go build -o /sshpiperd -ldflags "-X main.mainver=${VER}" ./cmd/...
+      go build -o /sshpiperd/plugins -tags "${BUILDTAGS}" ./plugin/... ./e2e/testplugin/...
+    fi
+HEREDOC
 ADD entrypoint.sh /sshpiperd
 
 FROM builder as testrunner
-
 COPY --from=farmer1992/openssh-static:V_9_8_P1 /usr/bin/ssh /usr/bin/ssh-9.8p1
 COPY --from=farmer1992/openssh-static:V_8_0_P1 /usr/bin/ssh /usr/bin/ssh-8.0p1
 
 FROM docker.io/busybox
-# LABEL maintainer="Boshi Lian<farmer1992@gmail.com>"
+RUN <<HEREDOC
+  # Add a non-root system (-S) user/group to run `sshpiperd` with:
+  addgroup -S sshpiperd -g "${GROUPID}"
+  adduser  -S sshpiperd -G -u "${USERID}" sshpiperd
 
-RUN mkdir /etc/ssh/
+  # Support `SSHPIPERD_SERVER_KEY_GENERATE_MODE=notexist` to create host key at `/etc/ssh`:
+  mkdir /etc/ssh/
+  chown -R "${USERID}:${GROUPID}" /etc/ssh/
+HEREDOC
+COPY --from=builder --chown=${USERID} /sshpiperd/ /sshpiperd
 
-# Add user nobody with id 1
-ARG USERID=1000
-ARG GROUPID=1000
-RUN addgroup -g $GROUPID -S sshpiperd && adduser -u $USERID -S sshpiperd -G sshpiperd
-
-# Add execution rwx to user 1
-RUN chown -R $USERID:$GROUPID /etc/ssh/
-
-USER $USERID:$GROUPID
-
-COPY --from=builder --chown=$USERID /sshpiperd/ /sshpiperd
+# Runtime setup:
+USER ${USERID}:${GROUPID}
 EXPOSE 2222
 
 ENTRYPOINT ["/sshpiperd/entrypoint.sh"]


### PR DESCRIPTION
This covers the [HereDoc syntax](https://docs.docker.com/reference/dockerfile/#here-documents) refactor for `Dockerfile` that was part of https://github.com/tg123/sshpiper/pull/563

As the `ENTRYPOINT` has not been altered, this should not be a breaking change.