### PR TITLE
extract skel into its own package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/tg123/sshpiper
 
 go 1.24.0
 
-toolchain go1.24.1
+toolchain go1.24.3
 
 replace golang.org/x/crypto => ./crypto
 

--- a/libplugin/util.go
+++ b/libplugin/util.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 func AuthMethodTypeToName(a AuthMethod) string {
@@ -89,7 +87,6 @@ func SplitHostPortForSSH(addr string) (host string, port int, err error) {
 
 // DialForSSH is the modified version of net.Dial, would add ":22" automaticlly
 func DialForSSH(addr string) (net.Conn, error) {
-
 	if _, _, err := net.SplitHostPort(addr); err != nil && addr != "" {
 		// test valid after concat :22
 		if _, _, err := net.SplitHostPort(addr + ":22"); err == nil {
@@ -153,23 +150,4 @@ func CreateRetryCurrentPluginAuth(meta map[string]string) *Upstream_RetryCurrent
 			Meta: meta,
 		},
 	}
-}
-
-func VerifyHostKeyFromKnownHosts(knownhostsData io.Reader, hostname, netaddr string, key []byte) error {
-	hostKeyCallback, err := knownhosts.NewFromReader(knownhostsData)
-	if err != nil {
-		return err
-	}
-
-	pub, err := ssh.ParsePublicKey(key)
-	if err != nil {
-		return err
-	}
-
-	addr, err := net.ResolveTCPAddr("tcp", netaddr)
-	if err != nil {
-		return err
-	}
-
-	return hostKeyCallback(hostname, addr, pub)
 }

--- a/plugin/docker/main.go
+++ b/plugin/docker/main.go
@@ -4,11 +4,11 @@ package main
 
 import (
 	"github.com/tg123/sshpiper/libplugin"
+	"github.com/tg123/sshpiper/libplugin/skel"
 	"github.com/urfave/cli/v2"
 )
 
 func main() {
-
 	libplugin.CreateAndRunPluginTemplate(&libplugin.PluginTemplate{
 		Name:  "docker",
 		Usage: "sshpiperd docker plugin, see config in https://github.com/tg123/sshpiper/tree/master/plugin/docker",
@@ -18,7 +18,7 @@ func main() {
 				return nil, err
 			}
 
-			skel := libplugin.NewSkelPlugin(plugin.listPipe)
+			skel := skel.NewSkelPlugin(plugin.listPipe)
 			return skel.CreateConfig(), nil
 		},
 	})

--- a/plugin/docker/skel.go
+++ b/plugin/docker/skel.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 
 	"github.com/tg123/sshpiper/libplugin"
+	"github.com/tg123/sshpiper/libplugin/skel"
 )
 
 type skelpipeWrapper struct {
@@ -40,18 +41,17 @@ type skelpipeToPrivateKeyWrapper struct {
 	skelpipeToWrapper
 }
 
-func (s *skelpipeWrapper) From() []libplugin.SkelPipeFrom {
-
+func (s *skelpipeWrapper) From() []skel.SkelPipeFrom {
 	w := skelpipeFromWrapper{
 		skelpipeWrapper: *s,
 	}
 
 	if s.pipe.PrivateKey != "" || s.pipe.AuthorizedKeys != "" {
-		return []libplugin.SkelPipeFrom{&skelpipePublicKeyWrapper{
+		return []skel.SkelPipeFrom{&skelpipePublicKeyWrapper{
 			skelpipeFromWrapper: w,
 		}}
 	} else {
-		return []libplugin.SkelPipeFrom{&skelpipePasswordWrapper{
+		return []skel.SkelPipeFrom{&skelpipePasswordWrapper{
 			skelpipeFromWrapper: w,
 		}}
 	}
@@ -73,7 +73,7 @@ func (s *skelpipeToWrapper) KnownHosts(conn libplugin.ConnMetadata) ([]byte, err
 	return nil, nil // TODO support this
 }
 
-func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.SkelPipeTo, error) {
+func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (skel.SkelPipeTo, error) {
 	user := conn.User()
 
 	matched := s.pipe.ClientUsername == user || s.pipe.ClientUsername == ""
@@ -130,13 +130,13 @@ func (s *skelpipeToPasswordWrapper) OverridePassword(conn libplugin.ConnMetadata
 	return nil, nil
 }
 
-func (p *plugin) listPipe(_ libplugin.ConnMetadata) ([]libplugin.SkelPipe, error) {
+func (p *plugin) listPipe(_ libplugin.ConnMetadata) ([]skel.SkelPipe, error) {
 	dpipes, err := p.list()
 	if err != nil {
 		return nil, err
 	}
 
-	var pipes []libplugin.SkelPipe
+	var pipes []skel.SkelPipe
 	for _, pipe := range dpipes {
 		wrapper := &skelpipeWrapper{
 			plugin: p,

--- a/plugin/kubernetes/main.go
+++ b/plugin/kubernetes/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/tg123/sshpiper/libplugin"
+	"github.com/tg123/sshpiper/libplugin/skel"
 	"github.com/urfave/cli/v2"
 )
 
@@ -28,7 +29,7 @@ func main() {
 			if err != nil {
 				return nil, err
 			}
-			skel := libplugin.NewSkelPlugin(plugin.listPipe)
+			skel := skel.NewSkelPlugin(plugin.listPipe)
 			return skel.CreateConfig(), nil
 		},
 	})

--- a/plugin/workingdir/main.go
+++ b/plugin/workingdir/main.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/pquerna/otp/totp"
 	"github.com/tg123/sshpiper/libplugin"
+	"github.com/tg123/sshpiper/libplugin/skel"
 	"github.com/urfave/cli/v2"
 )
 
 func main() {
-
 	libplugin.CreateAndRunPluginTemplate(&libplugin.PluginTemplate{
 		Name:  "workingdir",
 		Usage: "sshpiperd workingdir plugin",
@@ -54,7 +54,6 @@ func main() {
 			},
 		},
 		CreateConfig: func(c *cli.Context) (*libplugin.SshPiperPluginConfig, error) {
-
 			fac := workdingdirFactory{
 				root:             c.String("root"),
 				allowBadUsername: c.Bool("allow-baduser-name"),
@@ -66,10 +65,9 @@ func main() {
 
 			checktotp := c.Bool("check-totp")
 
-			skel := libplugin.NewSkelPlugin(fac.listPipe)
+			skel := skel.NewSkelPlugin(fac.listPipe)
 			config := skel.CreateConfig()
 			config.NextAuthMethodsCallback = func(conn libplugin.ConnMetadata) ([]string, error) {
-
 				auth := []string{"publickey"}
 
 				if !fac.noPasswordAuth {
@@ -80,7 +78,6 @@ func main() {
 					if conn.GetMeta("totp") != "checked" {
 						auth = []string{"keyboard-interactive"}
 					}
-
 				}
 
 				return auth, nil

--- a/plugin/workingdir/skel.go
+++ b/plugin/workingdir/skel.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/tg123/sshpiper/libplugin"
+	"github.com/tg123/sshpiper/libplugin/skel"
 )
 
 type workdingdirFactory struct {
@@ -50,18 +51,17 @@ type skelpipeToPrivateKeyWrapper struct {
 	skelpipeToWrapper
 }
 
-func (s *skelpipeWrapper) From() []libplugin.SkelPipeFrom {
-
+func (s *skelpipeWrapper) From() []skel.SkelPipeFrom {
 	w := skelpipeFromWrapper{
 		skelpipeWrapper: *s,
 	}
 
 	if s.dir.Exists(userAuthorizedKeysFile) && s.dir.Exists(userKeyFile) {
-		return []libplugin.SkelPipeFrom{&skelpipePublicKeyWrapper{
+		return []skel.SkelPipeFrom{&skelpipePublicKeyWrapper{
 			skelpipeFromWrapper: w,
 		}}
 	} else {
-		return []libplugin.SkelPipeFrom{&skelpipePasswordWrapper{
+		return []skel.SkelPipeFrom{&skelpipePasswordWrapper{
 			skelpipeFromWrapper: w,
 		}}
 	}
@@ -83,8 +83,7 @@ func (s *skelpipeToWrapper) KnownHosts(conn libplugin.ConnMetadata) ([]byte, err
 	return s.dir.Readfile(userKnownHosts)
 }
 
-func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.SkelPipeTo, error) {
-
+func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (skel.SkelPipeTo, error) {
 	if s.dir.Exists(userKeyFile) {
 		return &skelpipeToPrivateKeyWrapper{
 			skelpipeToWrapper: skelpipeToWrapper(*s),
@@ -121,8 +120,7 @@ func (s *skelpipeToPasswordWrapper) OverridePassword(conn libplugin.ConnMetadata
 	return nil, nil
 }
 
-func (wf *workdingdirFactory) listPipe(conn libplugin.ConnMetadata) ([]libplugin.SkelPipe, error) {
-
+func (wf *workdingdirFactory) listPipe(conn libplugin.ConnMetadata) ([]skel.SkelPipe, error) {
 	user := conn.User()
 
 	if !wf.allowBadUsername {
@@ -131,11 +129,10 @@ func (wf *workdingdirFactory) listPipe(conn libplugin.ConnMetadata) ([]libplugin
 		}
 	}
 
-	var pipes []libplugin.SkelPipe
+	var pipes []skel.SkelPipe
 	userdir := path.Join(wf.root, conn.User())
 
 	_ = filepath.Walk(userdir, func(path string, info os.FileInfo, err error) (stop error) {
-
 		log.Infof("search upstreams in path: %v", path)
 		if err != nil {
 			log.Infof("error walking path: %v", err)

--- a/plugin/workingdir/workingdir.go
+++ b/plugin/workingdir/workingdir.go
@@ -17,12 +17,10 @@ type workingdir struct {
 	Strict      bool
 }
 
-var (
-	// Base username validation on Debians default: https://sources.debian.net/src/adduser/3.113%2Bnmu3/adduser.conf/#L85
-	// -> NAME_REGEX="^[a-z][-a-z0-9_]*\$"
-	// The length is limited to 32 characters. See man 8 useradd: https://linux.die.net/man/8/useradd
-	usernameRule *regexp.Regexp = regexp.MustCompile("^[a-z_][-a-z0-9_]{0,31}$")
-)
+// Base username validation on Debians default: https://sources.debian.net/src/adduser/3.113%2Bnmu3/adduser.conf/#L85
+// -> NAME_REGEX="^[a-z][-a-z0-9_]*\$"
+// The length is limited to 32 characters. See man 8 useradd: https://linux.die.net/man/8/useradd
+var usernameRule *regexp.Regexp = regexp.MustCompile("^[a-z_][-a-z0-9_]{0,31}$")
 
 const (
 	userAuthorizedKeysFile = "authorized_keys"
@@ -52,7 +50,7 @@ func (w *workingdir) checkPerm(file string) error {
 		return nil
 	}
 
-	if fi.Mode().Perm()&0077 != 0 {
+	if fi.Mode().Perm()&0o077 != 0 {
 		return fmt.Errorf("%v's perm is too open", filename)
 	}
 

--- a/plugin/yaml/main.go
+++ b/plugin/yaml/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"github.com/tg123/sshpiper/libplugin"
+	"github.com/tg123/sshpiper/libplugin/skel"
 	"github.com/urfave/cli/v2"
 )
 
@@ -29,7 +30,7 @@ func main() {
 			},
 		},
 		CreateConfig: func(c *cli.Context) (*libplugin.SshPiperPluginConfig, error) {
-			skel := libplugin.NewSkelPlugin(plugin.listPipe)
+			skel := skel.NewSkelPlugin(plugin.listPipe)
 			return skel.CreateConfig(), nil
 		},
 	})

--- a/plugin/yaml/skel.go
+++ b/plugin/yaml/skel.go
@@ -4,12 +4,14 @@ package main
 
 import (
 	"errors"
-	log "github.com/sirupsen/logrus"
 	"os/user"
 	"regexp"
 	"slices"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/tg123/sshpiper/libplugin"
+	"github.com/tg123/sshpiper/libplugin/skel"
 )
 
 type skelpipeWrapper struct {
@@ -45,8 +47,8 @@ type skelpipeToPrivateKeyWrapper struct {
 	skelpipeToWrapper
 }
 
-func (s *skelpipeWrapper) From() []libplugin.SkelPipeFrom {
-	var froms []libplugin.SkelPipeFrom
+func (s *skelpipeWrapper) From() []skel.SkelPipeFrom {
+	var froms []skel.SkelPipeFrom
 	for _, f := range s.pipe.From {
 
 		w := &skelpipeFromWrapper{
@@ -87,7 +89,7 @@ func (s *skelpipeToWrapper) KnownHosts(conn libplugin.ConnMetadata) ([]byte, err
 	})
 }
 
-func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (libplugin.SkelPipeTo, error) {
+func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (skel.SkelPipeTo, error) {
 	username := conn.User()
 
 	targetuser := s.to.Username
@@ -175,7 +177,6 @@ func (s *skelpipeToPrivateKeyWrapper) PrivateKey(conn libplugin.ConnMetadata) ([
 		"DOWNSTREAM_USER": conn.User(),
 		"UPSTREAM_USER":   s.username,
 	})
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -187,13 +188,13 @@ func (s *skelpipeToPasswordWrapper) OverridePassword(conn libplugin.ConnMetadata
 	return nil, nil
 }
 
-func (p *plugin) listPipe(_ libplugin.ConnMetadata) ([]libplugin.SkelPipe, error) {
+func (p *plugin) listPipe(_ libplugin.ConnMetadata) ([]skel.SkelPipe, error) {
 	configs, err := p.loadConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	var pipes []libplugin.SkelPipe
+	var pipes []skel.SkelPipe
 	for _, config := range configs {
 		for _, pipe := range config.Pipes {
 			wrapper := &skelpipeWrapper{


### PR DESCRIPTION
This breaks the dependency of libplugin on x/crypto, enabling people to use libplugin without having conflicts over the crypto module.

It also (a) upgrades to go 1.24.3 and (b) runs gofmt, which makes a few incidental (whitespace/number literal) changes. If those are not OK, I can revert them.
