### PR TITLE
chore: drop crypto git submodule, consume sshpiper.crypto as Go module

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,9 +7,6 @@ sshpiper is a reverse proxy for SSH. It sits between SSH clients ("downstream") 
 ## Build
 
 ```bash
-# Clone with submodules (required — crypto/ is a submodule)
-git submodule update --init --recursive
-
 # Build root module (plugins, admin/webadmin CLI, libs)
 mkdir -p out
 go build -tags full -o out ./...
@@ -20,7 +17,7 @@ go build -tags full -o out ./...
 
 - **`-tags full`** includes all plugins. Without it, plugins are excluded from the build.
 - **CGO is not used** — all builds are pure Go (`CGO_ENABLED=0`).
-- **Two Go modules:** the root `github.com/tg123/sshpiper` module uses upstream `golang.org/x/crypto`; the nested `cmd/sshpiperd/go.mod` module contains the daemon and has `replace golang.org/x/crypto => ../../crypto` so only the daemon links against the fork.
+- **Two Go modules:** the root `github.com/tg123/sshpiper` module uses upstream `golang.org/x/crypto`; the nested `cmd/sshpiperd/go.mod` module contains the daemon and has `replace golang.org/x/crypto => github.com/tg123/sshpiper.crypto <tag>` so only the daemon links against the fork. **No git submodule** — the fork is pulled in as a regular Go module dependency.
 - GoReleaser handles release builds, multi-arch Docker images, and Snap packages (`.goreleaser.yaml`).
 
 ## Test
@@ -34,12 +31,12 @@ go test -v -race -cover -tags full ./...
 # Daemon module
 (cd cmd/sshpiperd && go test -v -race -cover ./...)
 
-# Forked crypto library
-(cd crypto/ssh && go test ./...)
-
 # Run a single test (specify the module/package)
 go test -v -tags full -run ^TestName$ ./path/to/package/
 ```
+
+> The forked `crypto/ssh` library is **not** tested from this repo — its tests live in the
+> [`tg123/sshpiper.crypto`](https://github.com/tg123/sshpiper.crypto) repository and run in that repo's own CI.
 
 ### E2E tests
 
@@ -73,25 +70,34 @@ Before considering any change/PR complete, you **must** verify all of these loca
 
 1. **`gofumpt -l .` produces empty output** (workflow: `.github/workflows/gofumpt.yml`). `gofmt` is not enough — this repo enforces `gofumpt`.
 2. **`go test -v -race -cover -tags full ./...` passes** in the root module, AND `cd cmd/sshpiperd && go test -v -race -cover ./...` passes in the daemon module (workflow: `.github/workflows/test.yml`).
-3. **`cd crypto/ssh && go test ./...` passes** — the forked crypto package is tested separately.
-4. **`golangci-lint run --build-tags full -D errcheck` passes for the root module AND `cd cmd/sshpiperd && golangci-lint run -D errcheck` passes for the daemon module** — both modules are linted independently.
-5. **`goreleaser release --snapshot --clean` succeeds** for release-affecting changes (Dockerfile, `.goreleaser.yaml`, new plugin binaries).
-6. **E2E suite passes** for changes touching the daemon, plugins, or crypto fork: `cd e2e && docker compose up --build --exit-code-from testrunner`.
+3. **`golangci-lint run --build-tags full -D errcheck` passes for the root module AND `cd cmd/sshpiperd && golangci-lint run -D errcheck` passes for the daemon module** — both modules are linted independently.
+4. **`goreleaser release --snapshot --clean` succeeds** for release-affecting changes (Dockerfile, `.goreleaser.yaml`, new plugin binaries).
+5. **E2E suite passes** for changes touching the daemon or plugins: `cd e2e && docker compose up --build --exit-code-from testrunner`.
 
 After pushing to a PR, **always check the GitHub Actions results** (`gh pr checks <pr>` or via the GitHub MCP). Do not declare the task done while any required check is failing or pending — push fixes until every gate is green. Common failure: forgetting to run `gofumpt -w .` after edits, or omitting `-tags full` when running tests/lint locally and missing plugin-specific issues.
 
 ## Architecture
 
-### Crypto fork (`crypto/`)
+### Crypto fork
 
-The `crypto/` directory is a **git submodule** containing a fork of `golang.org/x/crypto`. The fork is scoped to a single Go module so it does not leak into plugins:
+The forked `golang.org/x/crypto` lives in a **separate repository**,
+[`tg123/sshpiper.crypto`](https://github.com/tg123/sshpiper.crypto) (branch `v1`, tagged
+`vX.Y.Z-sshpiper-YYYYMMDD`). It is pulled in as a regular Go module dependency — there is **no git submodule**.
+The fork is scoped to a single Go module so it does not leak into plugins:
 
-- `cmd/sshpiperd/go.mod` (the daemon module) has `replace golang.org/x/crypto => ../../crypto`. Everything compiled into the `sshpiperd` binary uses the forked `ssh` package.
+- `cmd/sshpiperd/go.mod` (the daemon module) has `replace golang.org/x/crypto => github.com/tg123/sshpiper.crypto <tag>`. Everything compiled into the `sshpiperd` binary uses the forked `ssh` package.
 - The root `go.mod` does **not** replace `golang.org/x/crypto`. Every plugin under `plugin/*`, the libs under `libplugin/` / `libadmin/`, and the `sshpiperd-admin` / `sshpiperd-webadmin` CLIs build against upstream `golang.org/x/crypto` and therefore cannot import fork-only symbols.
 
-The key addition is `crypto/ssh/sshpiper.go`, which adds `PiperConfig` and `PiperConn` — the low-level API for intercepting SSH handshakes and piping two independent SSH connections together. Only the daemon module can reach those symbols.
+The key addition in the fork is `crypto/ssh/sshpiper.go`, which adds `PiperConfig` and `PiperConn` — the low-level API for intercepting SSH handshakes and piping two independent SSH connections together. Only the daemon module can reach those symbols.
 
-> Do not commit a `go.work` at the repo root: in workspace mode the daemon's `replace` would leak into root-module builds and destroy the isolation. If you want IDE/workspace support, create a local `go.work` (it is gitignored).
+> Do not commit a `go.work` at the repo root: in workspace mode the daemon's `replace` would leak into root-module builds and destroy the isolation. If you want IDE/workspace support — or to develop against a local checkout of `sshpiper.crypto` — create a local `go.work` (it is gitignored). Example:
+>
+> ```
+> go 1.26
+> use ./
+> use ./cmd/sshpiperd
+> use ../sshpiper.crypto
+> ```
 
 ### Plugin system
 
@@ -131,17 +137,18 @@ Use `plugin/fixed/` (~30 lines) or `plugin/simplemath/` as templates. A minimal 
 - The terms **downstream** (client side) and **upstream** (server side) are used consistently throughout the codebase.
 - **Private key remapping**: For public key auth, plugins must provide a "mapping key" for the upstream since the two SSH sessions have different `session_id` values.
 
-## Rebasing the crypto submodule onto upstream golang/crypto
+## Rebasing the crypto fork onto upstream golang/crypto
 
-The `crypto/` submodule (`https://github.com/tg123/sshpiper.crypto`, branch `v1`) is a fork of `https://github.com/golang/crypto` carrying sshpiper-specific patches (notably `crypto/ssh/sshpiper.go`). When upstream releases a new tag, follow this procedure to rebase:
+The fork (`https://github.com/tg123/sshpiper.crypto`, branch `v1`) is a fork of `https://github.com/golang/crypto` carrying sshpiper-specific patches (notably `crypto/ssh/sshpiper.go`). It lives in its own repo and is consumed by `cmd/sshpiperd` as a regular Go module dependency (`replace golang.org/x/crypto => github.com/tg123/sshpiper.crypto <tag>`). When upstream releases a new tag, follow this procedure to rebase:
 
-1. **Find the latest upstream tag.** List tags from `https://github.com/golang/crypto` and pick the newest `vX.Y.Z`:
+1. **Clone the fork repo locally** (alongside your sshpiper checkout):
    ```bash
-   cd crypto
+   git clone https://github.com/tg123/sshpiper.crypto ../sshpiper.crypto
+   cd ../sshpiper.crypto
+   git remote add upstream https://github.com/golang/crypto.git   # one-time
    git fetch upstream --tags
    git --no-pager tag --sort=-v:refname --list 'v*' | grep -v sshpiper | head
    ```
-   If the `upstream` remote is missing, add it: `git remote add upstream https://github.com/golang/crypto.git`.
 
 2. **Rebase the sshpiper patches onto the new tag.** Do the work on a throwaway branch first so `v1` isn't disturbed if you need to retry:
    ```bash
@@ -149,22 +156,15 @@ The `crypto/` submodule (`https://github.com/tg123/sshpiper.crypto`, branch `v1`
    git checkout -b rebase-<new-upstream-tag> v1
    git rebase <new-upstream-tag>     # e.g. v0.50.0
    ```
-   Resolve conflicts — most patches live in `crypto/ssh/sshpiper.go` and small touches to `crypto/ssh/server.go` / `client_auth.go`. There are typically ~17 sshpiper patches; recent rebases (e.g. v0.48.0 → v0.50.0) have applied cleanly with no conflicts.
+   Resolve conflicts — most patches live in `ssh/sshpiper.go` and small touches to `ssh/server.go` / `client_auth.go`. There are typically ~17 sshpiper patches; recent rebases have applied cleanly with no conflicts.
 
-3. **Verify tests pass** in the submodule first, then in the main repo:
+3. **Verify tests pass** in the fork repo:
    ```bash
-   cd crypto/ssh && go test ./...
-   cd ../..
-   # Bump golang.org/x/crypto require line in go.mod to match the new upstream tag
-   #   sed -i 's|golang.org/x/crypto v[0-9.]*|golang.org/x/crypto v0.50.0|' go.mod
-   go mod tidy            # required — new upstream often pulls in newer x/sys, x/term
-   go build -tags full ./...
-   go test -race -tags full ./...
+   cd ssh && go test ./...
    ```
 
 4. **Move `v1` and tag, then push to the fork.** Tag format is **`<upstream-tag>-sshpiper-<YYYYMMDD>`** (e.g. `v0.50.0-sshpiper-20260423`). Use `--force-with-lease` because `v1` history was rewritten:
    ```bash
-   cd crypto
    git branch -f v1 rebase-<new-upstream-tag>
    git checkout v1
    TAG="<new-upstream-tag>-sshpiper-$(date -u +%Y%m%d)"
@@ -173,14 +173,20 @@ The `crypto/` submodule (`https://github.com/tg123/sshpiper.crypto`, branch `v1`
    git push origin "$TAG"
    ```
 
-5. **Open the sshpiper PR.** Branch off the latest `origin/master` (not local `master`, which may be stale):
+5. **Open the sshpiper PR.** Branch off the latest `origin/master` (not local `master`, which may be stale), bump both the `require` and `replace` lines in `cmd/sshpiperd/go.mod`, and tidy:
    ```bash
-   cd ..   # back to sshpiper repo root
+   cd <sshpiper-repo>
    git fetch origin
    git checkout -b chore/rebase-crypto-<new-upstream-tag> origin/master
-   git add crypto go.mod go.sum
+   # In cmd/sshpiperd/go.mod, bump:
+   #   - the golang.org/x/crypto require line to the new upstream version
+   #   - the replace target to github.com/tg123/sshpiper.crypto <new-tag>
+   (cd cmd/sshpiperd && go mod tidy)
+   # Root module may also need its golang.org/x/crypto require bumped:
+   go mod tidy
+   git add go.mod go.sum cmd/sshpiperd/go.mod cmd/sshpiperd/go.sum
    git commit -m "chore: rebase crypto onto <new-upstream-tag>"
    git push -u origin HEAD
    gh pr create --fill
    ```
-   Confirm `git ls-tree HEAD crypto` shows the new submodule SHA. If you instead rebased a feature branch onto a moved `origin/master` and hit `go.mod`/`go.sum` conflicts, note that **`--ours`/`--theirs` are reversed during rebase** (`--ours` = `origin/master`, `--theirs` = your branch). Easiest resolution: `git checkout --ours go.mod go.sum`, re-bump `golang.org/x/crypto` to the new version, then `go mod tidy && git add go.mod go.sum && git rebase --continue`. After pushing, verify all CI gates pass (see "Required PR gates" above).
+   If you rebased a feature branch onto a moved `origin/master` and hit `go.mod`/`go.sum` conflicts, note that **`--ours`/`--theirs` are reversed during rebase** (`--ours` = `origin/master`, `--theirs` = your branch). Easiest resolution: `git checkout --ours go.mod go.sum`, re-bump `golang.org/x/crypto`, then `go mod tidy && git add go.mod go.sum && git rebase --continue`. After pushing, verify all CI gates pass (see "Required PR gates" above).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,7 +88,7 @@ The fork is scoped to a single Go module so it does not leak into plugins:
 - `cmd/sshpiperd/go.mod` (the daemon module) has `replace golang.org/x/crypto => github.com/tg123/sshpiper.crypto <tag>`. Everything compiled into the `sshpiperd` binary uses the forked `ssh` package.
 - The root `go.mod` does **not** replace `golang.org/x/crypto`. Every plugin under `plugin/*`, the libs under `libplugin/` / `libadmin/`, and the `sshpiperd-admin` / `sshpiperd-webadmin` CLIs build against upstream `golang.org/x/crypto` and therefore cannot import fork-only symbols.
 
-The key addition in the fork is `crypto/ssh/sshpiper.go`, which adds `PiperConfig` and `PiperConn` — the low-level API for intercepting SSH handshakes and piping two independent SSH connections together. Only the daemon module can reach those symbols.
+The key addition in the fork is `ssh/sshpiper.go`, which adds `PiperConfig` and `PiperConn` — the low-level API for intercepting SSH handshakes and piping two independent SSH connections together. Only the daemon module can reach those symbols.
 
 > Do not commit a `go.work` at the repo root: in workspace mode the daemon's `replace` would leak into root-module builds and destroy the isolation. If you want IDE/workspace support — or to develop against a local checkout of `sshpiper.crypto` — create a local `go.work` (it is gitignored). Example:
 >
@@ -139,7 +139,7 @@ Use `plugin/fixed/` (~30 lines) or `plugin/simplemath/` as templates. A minimal 
 
 ## Rebasing the crypto fork onto upstream golang/crypto
 
-The fork (`https://github.com/tg123/sshpiper.crypto`, branch `v1`) is a fork of `https://github.com/golang/crypto` carrying sshpiper-specific patches (notably `crypto/ssh/sshpiper.go`). It lives in its own repo and is consumed by `cmd/sshpiperd` as a regular Go module dependency (`replace golang.org/x/crypto => github.com/tg123/sshpiper.crypto <tag>`). When upstream releases a new tag, follow this procedure to rebase:
+The fork (`https://github.com/tg123/sshpiper.crypto`, branch `v1`) is a fork of `https://github.com/golang/crypto` carrying sshpiper-specific patches (notably `ssh/sshpiper.go`). It lives in its own repo and is consumed by `cmd/sshpiperd` as a regular Go module dependency (`replace golang.org/x/crypto => github.com/tg123/sshpiper.crypto <tag>`). When upstream releases a new tag, follow this procedure to rebase:
 
 1. **Clone the fork repo locally** (alongside your sshpiper checkout):
    ```bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,8 +16,6 @@ jobs:
 
     - name: Check out code
       uses: actions/checkout@v6
-      with:
-        ref: ${{ github.event.workflow_run.head_sha }}      
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,8 +17,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v6
       with:
-        ref: ${{ github.event.workflow_run.head_sha }}
-        submodules: 'recursive'      
+        ref: ${{ github.event.workflow_run.head_sha }}      
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,6 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
-          submodules: 'recursive'
 
       - name: Repo SemVer
         uses: lhstrh/action-repo-semver@v1.2.1
@@ -44,8 +43,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 0
-          submodules: 'recursive'     
+          fetch-depth: 0     
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Repo SemVer
@@ -42,7 +41,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0     
 
       - name: Set up QEMU

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,18 +16,12 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v6
-      with:
-        submodules: 'recursive'
 
     - name: Set up Go 1.26.x
       uses: actions/setup-go@v6
       with:
         go-version: '1.26.x'
         cache: true
-
-    - name: Test lib ssh
-      run: go test -v -cover ./...
-      working-directory: crypto/ssh
 
     - name: Test sshpiper (root module)
       run: go test -v -race -cover -tags full ./...

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "crypto"]
-	path = crypto
-	url = https://github.com/tg123/sshpiper.crypto

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,19 @@ Make sure you have read [README.md](README.md) before starting.
 
 ### Get the code
 
-remember to clone the submodules
-
 ```
 git clone https://github.com/tg123/sshpiper
 cd sshpiper
-git submodule update --init --recursive
 ```
+
+> The forked `golang.org/x/crypto` (carrying sshpiper's `PiperConfig`/`PiperConn` API) lives in a separate repo,
+> [`tg123/sshpiper.crypto`](https://github.com/tg123/sshpiper.crypto), and is pulled in as a regular Go module
+> dependency of `cmd/sshpiperd` via `replace` — no `git submodule` step is needed.
+>
+> If you want to hack on the fork against your local sshpiper checkout, create a (gitignored) `go.work` at the
+> repo root that `use`s both `./cmd/sshpiperd` and your local clone of `sshpiper.crypto`. Do **not** commit
+> `go.work`: workspace mode would apply the daemon's `replace golang.org/x/crypto` graph-wide and leak the
+> fork into root/plugin module builds.
 
 ### Start Develop Environment
 
@@ -59,8 +65,12 @@ go test
 
 ### sshpiper seasoned crypto ssh lib
 
-The `crypto` folder contains the source code of the [sshpiper seasoned crypto ssh lib](./crypto/).
-It based on [crypto/ssh](https://golang.org/pkg/crypto/ssh/) and with a drop-in [sshpiper.go](./crypto/ssh/sshpiper.go) to expose all low level sshpiper required APIs.
+The forked `crypto/ssh` library (with sshpiper-specific extensions like `PiperConfig`/`PiperConn`) lives in a
+separate repository: [`tg123/sshpiper.crypto`](https://github.com/tg123/sshpiper.crypto). It is based on
+[crypto/ssh](https://golang.org/pkg/crypto/ssh/) with a drop-in `sshpiper.go` exposing the low-level APIs
+sshpiper needs. It is consumed only by the `cmd/sshpiperd` Go module (via a `replace` directive pinned to a
+versioned tag of the fork), so plugins and libs in this repo always build against upstream
+`golang.org/x/crypto`.
 
 ### sshpiperd
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@
 ```
 git clone https://github.com/tg123/sshpiper
 cd sshpiper
-git submodule update --init --recursive
 
 mkdir out
 go build -tags full -o out ./...
+(cd cmd/sshpiperd && go build -o ../../out/ .)
 ```
 
 ## Run simple demo

--- a/cmd/sshpiperd/go.mod
+++ b/cmd/sshpiperd/go.mod
@@ -5,7 +5,11 @@ go 1.26.0
 // The forked golang.org/x/crypto (carrying sshpiper's PiperConfig/PiperConn API)
 // is scoped to this module only. The root github.com/tg123/sshpiper module and
 // every plugin under it build against upstream golang.org/x/crypto.
-replace golang.org/x/crypto => ../../crypto
+//
+// For local development against an unreleased fork commit, create a (gitignored)
+// go.work at the repo root that `use`s both `./cmd/sshpiperd` and your local
+// checkout of github.com/tg123/sshpiper.crypto.
+replace golang.org/x/crypto => github.com/tg123/sshpiper.crypto v0.52.0-sshpiper-20260524
 
 replace github.com/tg123/sshpiper => ../..
 

--- a/cmd/sshpiperd/go.sum
+++ b/cmd/sshpiperd/go.sum
@@ -30,6 +30,8 @@ github.com/tg123/jobobject v0.1.0 h1:deOWVH+SvsnFtT/M+HFhtZ7t9GMYPzYMvvF25IIMRRE
 github.com/tg123/jobobject v0.1.0/go.mod h1:TtbMLKdmTPY6eMo4aqDXiQWv0yTfAgDt1mxv6J9pM8o=
 github.com/tg123/remotesigner v0.0.3 h1:OA+yzMtlUFwkFpawyu0adG0Jq2NJzw8X7mP/+Z4OxuQ=
 github.com/tg123/remotesigner v0.0.3/go.mod h1:vborNv1HjfGLNCFJhUSmcAqqwks4AE1pE8ind6YDuII=
+github.com/tg123/sshpiper.crypto v0.52.0-sshpiper-20260524 h1:2rAFfym6DC5TC05o8rNxb2/VR/ZTkjC9EwR9hgoivMs=
+github.com/tg123/sshpiper.crypto v0.52.0-sshpiper-20260524/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=


### PR DESCRIPTION
The forked `golang.org/x/crypto` (carrying sshpiper's `PiperConfig`/`PiperConn` API) lives in a separate repository, [`tg123/sshpiper.crypto`](https://github.com/tg123/sshpiper.crypto). It is only used by the `cmd/sshpiperd` daemon module via a `replace` directive — plugins and libs build against upstream `golang.org/x/crypto`.

Until now, the fork was vendored as a git submodule under `crypto/` and the daemon's `replace` pointed at `../../crypto`. That required everyone (humans and CI) to run `git submodule update --init --recursive` as an extra step, and the submodule had no semantic role at runtime: the fork is already published as a Go module with tags of the form `vX.Y.Z-sshpiper-YYYYMMDD`.

### Changes

- Remove the `crypto/` submodule and `.gitmodules`.
- Repoint `cmd/sshpiperd/go.mod`'s replace to `github.com/tg123/sshpiper.crypto v0.52.0-sshpiper-20260524` (the same commit the submodule was pinned at on master).
- Drop `submodules: 'recursive'` from all GitHub Actions workflows (`test.yml`, `e2e.yml`, `release.yaml`).
- Drop the `crypto/ssh` test step from CI — the fork has its own tests in its own repo.
- Update `README.md`, `CONTRIBUTING.md`, and `.github/copilot-instructions.md`:
  - No more submodule step in the build/clone instructions.
  - Rebase workflow now bumps the module version instead of the submodule SHA.
  - Document the local-dev `go.work` pattern for hacking on the fork against a local checkout — still **gitignored**, because workspace mode would apply the daemon's `replace golang.org/x/crypto` graph-wide and leak the fork into root/plugin module builds, breaking the isolation that the two-module setup exists to enforce.

### Verification

- `go build -tags full ./...` (root module) ✅
- `cd cmd/sshpiperd && go build ./...` ✅
- `gofumpt -l .` empty ✅
- `go.sum` for daemon module populated with fork hash (tamper-proof, reproducible)
- Plugin builds untouched — they never referenced the fork