### PR TITLE
perf(benchmark): capture pprof/heap profiles from benchmark runs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,6 +32,28 @@ jobs:
         SSHPIPERD_BENCHMARKS: "1"
         SSHPIPERD_SKIP_E2E: "1"
 
+    - name: Copy benchmark profiles out of shared volume
+      if: always()
+      working-directory: e2e
+      run: |
+        mkdir -p ./bench-profiles
+        # Run a one-shot helper container that mounts the same `shared`
+        # named volume and copies any pprof files out to the host.
+        docker run --rm \
+          -v "e2e_shared:/shared:ro" \
+          -v "$PWD/bench-profiles:/out" \
+          alpine:3 \
+          sh -c 'cp /shared/*.prof /out/ 2>/dev/null || true; ls -l /out'
+
+    - name: Upload benchmark profiles
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-profiles
+        path: e2e/bench-profiles/*.prof
+        if-no-files-found: warn
+        retention-days: 14
+
     - name: Show benchmark result
       if: always()
       working-directory: e2e

--- a/cmd/sshpiperd/main.go
+++ b/cmd/sshpiperd/main.go
@@ -313,6 +313,12 @@ func main() {
 				Usage:   "CA certificate (PEM) used to verify admin gRPC clients. When set, mutual TLS is required and clients must present a certificate signed by this CA",
 				EnvVars: []string{"SSHPIPERD_ADMIN_GRPC_TLS_CACERT"},
 			},
+			&cli.StringFlag{
+				Name:    "pprof-listen-address",
+				Value:   "",
+				Usage:   "if non-empty, expose net/http/pprof handlers on this address (e.g. 127.0.0.1:6060) for profiling. Off by default; only safe on a trusted local network",
+				EnvVars: []string{"SSHPIPERD_PPROF_LISTEN_ADDRESS"},
+			},
 		},
 		Action: func(ctx *cli.Context) error {
 			level, err := slogutil.ParseLevel(ctx.String("log-level"))
@@ -332,6 +338,14 @@ func main() {
 			}
 
 			slog.Info("starting sshpiperd", "version", version())
+
+			if addr := ctx.String("pprof-listen-address"); addr != "" {
+				if err := startPprofServer(addr); err != nil {
+					return fmt.Errorf("start pprof listener: %w", err)
+				}
+				slog.Info("pprof handlers enabled", "address", addr)
+			}
+
 			d, err := newDaemon(ctx)
 			if err != nil {
 				return err

--- a/cmd/sshpiperd/pprof.go
+++ b/cmd/sshpiperd/pprof.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"time"
+)
+
+// startPprofServer binds a tiny HTTP server on addr that serves the standard
+// net/http/pprof handlers. It returns once the listener is bound so callers
+// know the endpoint is reachable; the server then runs in a background
+// goroutine for the rest of the process lifetime.
+//
+// Only intended for benchmarking / debugging — the caller (CLI flag) gates
+// this off by default and the docs warn that it must not be exposed on a
+// public network.
+func startPprofServer(addr string) error {
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		if err := srv.Serve(lis); err != nil && err != http.ErrServerClosed {
+			slog.Warn("pprof server stopped", "error", err)
+		}
+	}()
+
+	return nil
+}

--- a/e2e/benchmark_test.go
+++ b/e2e/benchmark_test.go
@@ -22,6 +22,8 @@ const (
 	benchmarkCipherDefault      = "aes128-gcm@openssh.com"
 	benchmarkScpTarget          = "/shared/bench-scp-payload"
 	benchmarkUpstreamAddr       = "host-publickey:2222"
+	benchmarkPprofAddr          = "127.0.0.1:6060"
+	benchmarkPprofAddrEnv       = "SSHPIPERD_BENCH_PPROF_ADDR"
 )
 
 var benchmarkPayloadSize = resolveBenchmarkPayloadSize()
@@ -61,6 +63,8 @@ func BenchmarkTransferRate(b *testing.B) {
 	piper, _, _, err := runCmd("/sshpiperd/sshpiperd",
 		"-p",
 		piperport,
+		"--pprof-listen-address",
+		benchmarkPprofAddr,
 		"/sshpiperd/plugins/benchmark",
 		"--target",
 		benchmarkUpstreamAddr,

--- a/e2e/e2eentry.sh
+++ b/e2e/e2eentry.sh
@@ -29,14 +29,63 @@ else
         umask "${old_umask}"
         chmod 600 "${bench_output}"
         trap "rm -f \"${bench_output}\"" EXIT
-        go test -v -bench=. -run=^$ -benchtime="${bench_time}" . | tee "${bench_output}"
+
+        # Profiles are written to /shared so the benchmark workflow can upload
+        # them as CI artifacts. They cover:
+        #   - bench-cpu.prof / bench-mem.prof: the benchmark process (ssh
+        #     client driver). Useful to verify the harness is not the
+        #     bottleneck.
+        #   - sshpiperd-cpu.prof / sshpiperd-heap.prof: scraped from the
+        #     sshpiperd daemon's pprof endpoint started by the e2e benchmark
+        #     test (via --pprof-listen-address). These show where the proxy
+        #     spends time under load.
+        profile_dir="${SSHPIPERD_BENCH_PROFILE_DIR:-/shared}"
+        mkdir -p "${profile_dir}"
+        bench_cpu_profile="${profile_dir}/bench-cpu.prof"
+        bench_mem_profile="${profile_dir}/bench-mem.prof"
+        piper_cpu_profile="${profile_dir}/sshpiperd-cpu.prof"
+        piper_heap_profile="${profile_dir}/sshpiperd-heap.prof"
+        piper_pprof_addr="${SSHPIPERD_BENCH_PPROF_ADDR:-127.0.0.1:6060}"
+
+        # Scrape the sshpiperd pprof endpoint while the benchmark is running.
+        # The endpoint is only live during BenchmarkTransferRate (the
+        # baseline benchmark runs without a piper). We poll until the
+        # endpoint comes up, then capture a CPU profile spanning most of
+        # the bench window plus a heap snapshot at the end.
+        scrape_seconds="${SSHPIPERD_BENCH_PROFILE_SECONDS:-30}"
+        (
+            for _ in $(seq 1 120); do
+                if curl -fsS "http://${piper_pprof_addr}/debug/pprof/" >/dev/null 2>&1; then
+                    break
+                fi
+                sleep 1
+            done
+            curl -fsS "http://${piper_pprof_addr}/debug/pprof/profile?seconds=${scrape_seconds}" \
+                -o "${piper_cpu_profile}" || \
+                echo "warning: failed to capture sshpiperd cpu profile"
+            curl -fsS "http://${piper_pprof_addr}/debug/pprof/heap" \
+                -o "${piper_heap_profile}" || \
+                echo "warning: failed to capture sshpiperd heap profile"
+        ) &
+        pprof_pid=$!
+
+        go test -v -bench=. -benchmem -run=^$ -benchtime="${bench_time}" \
+            -cpuprofile "${bench_cpu_profile}" \
+            -memprofile "${bench_mem_profile}" \
+            . | tee "${bench_output}"
         bench_exit_code=$?
+
+        wait "${pprof_pid}" 2>/dev/null || true
 
         if [ "${bench_exit_code}" -ne 0 ]; then
             exit ${bench_exit_code}
         fi
 
         set +x
+
+        echo "benchmark profiles written to ${profile_dir}:"
+        ls -lh "${bench_cpu_profile}" "${bench_mem_profile}" \
+            "${piper_cpu_profile}" "${piper_heap_profile}" 2>/dev/null || true
 
         echo "benchmark summary (sshpiper vs baseline)"
         bench_cases="scp_upload,ssh_stream"


### PR DESCRIPTION
## Why

scp_upload currently runs at ~95% of baseline; ssh_stream at ~104%. To know where the piper spends time on the small-packet/ACK-heavy scp workload (and to be able to optimize without guessing), the benchmark workflow needs to produce CPU and heap profiles.

## What

- New `--pprof-listen-address` flag on sshpiperd (env `SSHPIPERD_PPROF_LISTEN_ADDRESS`). Off by default; serves the standard `net/http/pprof` handlers when set. Docs warn it must only be used on trusted networks.
- e2e benchmark passes `--pprof-listen-address 127.0.0.1:6060` to the piper it spawns.
- `e2eentry.sh` runs benchmarks with `-cpuprofile`/`-memprofile`/`-benchmem`. In parallel, it polls the piper's pprof endpoint and scrapes a 30s CPU profile + a heap snapshot. All four `.prof` files land in the shared volume.
- The benchmark workflow copies the `.prof` files out of the named volume and uploads them as a `benchmark-profiles` artifact (14-day retention).

## Use

After CI runs, download the `benchmark-profiles` artifact and inspect:

```
go tool pprof -http :8080 sshpiperd-cpu.prof
go tool pprof -http :8080 sshpiperd-heap.prof
```

No behaviour change to non-benchmark builds. The pprof endpoint is opt-in.