### PR TITLE
fix(daemon): keep username-based recording dir within configured root

### DIFF
--- a/cmd/sshpiperd/asciicast.go
+++ b/cmd/sshpiperd/asciicast.go
@@ -45,13 +45,20 @@ type asciicastLogger struct {
 	initHeight   uint32
 	channels     map[uint32]*os.File
 	channelIDMap map[uint32]uint32
+	root         *os.Root
 	recorddir    string
 	prefix       string // prefix for the output file
 }
 
-func newAsciicastLogger(recorddir string, prefix string) *asciicastLogger {
+// newAsciicastLogger creates a recorder that writes .cast files under
+// recorddir, a subdirectory name relative to root. root is opened on the
+// configured screen recording root (see daemon.recordRoot); every file this
+// logger opens goes through root.OpenFile so that even if recorddir
+// contains a symlink planted by an attacker, the write cannot escape root.
+func newAsciicastLogger(root *os.Root, recorddir string, prefix string) *asciicastLogger {
 	return &asciicastLogger{
 		envs:         make(map[string]string),
+		root:         root,
 		recorddir:    recorddir,
 		channels:     make(map[uint32]*os.File),
 		channelIDMap: make(map[uint32]uint32),
@@ -121,7 +128,7 @@ func (l *asciicastLogger) downhook(msg []byte) error {
 				return err
 			}
 
-			f, err := os.OpenFile(
+			f, err := l.root.OpenFile(
 				path.Join(l.recorddir, fmt.Sprintf("%s%s-channel-%d.cast", l.prefix, reqType, clientChannelID)),
 				os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
 				0o600,

--- a/cmd/sshpiperd/daemon.go
+++ b/cmd/sshpiperd/daemon.go
@@ -264,6 +264,22 @@ func loadHostKeys(ctx *cli.Context) ([]ssh.Signer, error) {
 	return signers, nil
 }
 
+// safeJoinUserRecordDir joins base with the (attacker-controlled) SSH
+// username to build the per-user recording directory, and verifies that the
+// resulting path does not escape base. A malicious username such as
+// "../../etc" or containing path separators must not be able to make the
+// recording directory land outside of base.
+func safeJoinUserRecordDir(base, user string) (string, error) {
+	dir := filepath.Join(base, user)
+
+	rel, err := filepath.Rel(base, dir)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("resulting recording dir %q escapes recording root %q", dir, base)
+	}
+
+	return dir, nil
+}
+
 func newDaemon(ctx *cli.Context) (*daemon, error) {
 	config := &plugin.GrpcPluginConfig{}
 
@@ -470,12 +486,12 @@ func (d *daemon) run() error {
 				var recorddir string
 				if d.usernameAsRecorddir {
 					user := p.DownstreamConnMeta().User()
-					recorddir = filepath.Join(d.recorddir, user)
-					// make sure the resulting path stays within d.recorddir
-					if rel, rerr := filepath.Rel(d.recorddir, recorddir); rerr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-						slog.Error("invalid username for screen recording dir", "user", user)
+					dir, serr := safeJoinUserRecordDir(d.recorddir, user)
+					if serr != nil {
+						slog.Error("invalid username for screen recording dir", "user", user, "error", serr)
 						return
 					}
+					recorddir = dir
 				} else {
 					uniqID := plugin.GetUniqueID(p.ChallengeContext())
 					recorddir = filepath.Join(d.recorddir, uniqID)

--- a/cmd/sshpiperd/daemon.go
+++ b/cmd/sshpiperd/daemon.go
@@ -10,8 +10,8 @@ import (
 	"log/slog"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/tg123/sshpiper/cmd/sshpiperd/internal/admin"
@@ -469,10 +469,16 @@ func (d *daemon) run() error {
 			if d.recorddir != "" {
 				var recorddir string
 				if d.usernameAsRecorddir {
-					recorddir = path.Join(d.recorddir, p.DownstreamConnMeta().User())
+					user := p.DownstreamConnMeta().User()
+					recorddir = filepath.Join(d.recorddir, user)
+					// make sure the resulting path stays within d.recorddir
+					if rel, rerr := filepath.Rel(d.recorddir, recorddir); rerr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+						slog.Error("invalid username for screen recording dir", "user", user)
+						return
+					}
 				} else {
 					uniqID := plugin.GetUniqueID(p.ChallengeContext())
-					recorddir = path.Join(d.recorddir, uniqID)
+					recorddir = filepath.Join(d.recorddir, uniqID)
 				}
 				err = os.MkdirAll(recorddir, 0o700)
 				if err != nil {

--- a/cmd/sshpiperd/daemon.go
+++ b/cmd/sshpiperd/daemon.go
@@ -33,6 +33,15 @@ type daemon struct {
 	disableLocalForward   bool
 	disableRemoteForward  bool
 
+	// recordRoot is an os.Root scoped to recorddir, opened by
+	// initScreenRecording. All per-connection recording directories and
+	// files are created/opened through it (see setupScreenRecording),
+	// since os.Root refuses to resolve any path component -- including
+	// through a symlink -- outside of the directory it was opened on. This
+	// is the actual containment boundary for screen recording; the lexical
+	// checks in safeJoinUserRecordDir are only a defense-in-depth measure.
+	recordRoot *os.Root
+
 	// injectEnv is merged into every upstream session's env-injection.
 	// Plugin-provided env (Upstream.Env) takes precedence on key
 	// collisions. Empty (nil/zero-length) means no global injection.
@@ -265,10 +274,19 @@ func loadHostKeys(ctx *cli.Context) ([]ssh.Signer, error) {
 }
 
 // safeJoinUserRecordDir joins base with the (attacker-controlled) SSH
-// username to build the per-user recording directory, and verifies that the
-// resulting path does not escape base. A malicious username such as
-// "../../etc" or containing path separators must not be able to make the
-// recording directory land outside of base.
+// username to build the per-user recording directory name, and verifies
+// that the resulting path does not lexically escape base. A malicious
+// username such as "../../etc" or containing path separators must not be
+// able to make the recording directory land outside of base. On success it
+// returns that directory's name relative to base (e.g. "alice"), for use as
+// a subdirectory of the os.Root opened on base (see daemon.recordRoot).
+//
+// This lexical check is only a defense-in-depth measure: it rejects
+// malicious usernames early with a clear error, but it cannot detect a
+// symlink placed under base (before or during the daemon's lifetime) that
+// would cause the resulting path to be resolved outside of base. The actual
+// containment boundary is the os.Root the returned name is subsequently
+// used with, which refuses to follow such a symlink out of the root.
 func safeJoinUserRecordDir(base, user string) (string, error) {
 	dir := filepath.Join(base, user)
 
@@ -277,7 +295,7 @@ func safeJoinUserRecordDir(base, user string) (string, error) {
 		return "", fmt.Errorf("resulting recording dir %q escapes recording root %q", dir, base)
 	}
 
-	return dir, nil
+	return rel, nil
 }
 
 func newDaemon(ctx *cli.Context) (*daemon, error) {
@@ -399,9 +417,105 @@ func (d *daemon) install(plugins ...*plugin.GrpcPlugin) error {
 	return m.InstallPiperConfig(d.config)
 }
 
+// initScreenRecording prepares screen recording, if enabled via
+// --screen-recording-dir: it ensures the configured recording root exists
+// and opens an os.Root scoped to it. Every per-connection recording
+// directory/file is subsequently created/opened through that root (see
+// setupScreenRecording), so a symlink placed under the recording root --
+// whether pre-existing or planted while the daemon is running -- cannot be
+// used to escape it. It is a no-op if recording is disabled.
+func (d *daemon) initScreenRecording() error {
+	if d.recorddir == "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(d.recorddir, 0o700); err != nil {
+		return fmt.Errorf("cannot create screen recording root %q: %w", d.recorddir, err)
+	}
+
+	root, err := os.OpenRoot(d.recorddir)
+	if err != nil {
+		return fmt.Errorf("cannot open screen recording root %q: %w", d.recorddir, err)
+	}
+
+	d.recordRoot = root
+	return nil
+}
+
+// setupScreenRecording wires the screen-recording packet-inspection hooks
+// for a single piped connection into uphookchain/downhookchain.
+//
+// ok reports whether the caller should proceed with the connection. It is
+// true when screen recording is disabled (d.recordRoot == nil, closer is
+// nil) or was set up successfully (closer releases the recorder's resources
+// and must be called once the connection ends, if non-nil). It is false
+// when screen recording is enabled but this particular connection must be
+// rejected -- e.g. the downstream username fails the
+// --username-as-recorddir path-traversal guard, or the recording
+// directory/files could not be created -- in which case the caller must
+// abort the connection entirely, matching sshpiperd's historical
+// fail-closed behavior for screen recording.
+func (d *daemon) setupScreenRecording(p *ssh.PiperConn, uphookchain, downhookchain *hookChain) (closer func() error, ok bool) {
+	if d.recordRoot == nil {
+		return nil, true
+	}
+
+	var subdir string
+	if d.usernameAsRecorddir {
+		user := p.DownstreamConnMeta().User()
+		rel, err := safeJoinUserRecordDir(d.recorddir, user)
+		if err != nil {
+			slog.Error("invalid username for screen recording dir", "user", user, "error", err)
+			return nil, false
+		}
+		subdir = rel
+	} else {
+		subdir = plugin.GetUniqueID(p.ChallengeContext())
+	}
+
+	if err := d.recordRoot.MkdirAll(subdir, 0o700); err != nil {
+		slog.Error("cannot create screen recording dir", "recorddir", subdir, "error", err)
+		return nil, false
+	}
+
+	switch d.recordfmt {
+	case "asciicast":
+		prefix := ""
+		if d.usernameAsRecorddir {
+			// add prefix to avoid conflict
+			prefix = fmt.Sprintf("%d-", time.Now().Unix())
+		}
+		recorder := newAsciicastLogger(d.recordRoot, subdir, prefix)
+
+		uphookchain.append(ssh.InspectPacketHook(recorder.uphook))
+		downhookchain.append(ssh.InspectPacketHook(recorder.downhook))
+
+		return recorder.Close, true
+	case "typescript":
+		recorder, err := newFilePtyLogger(d.recordRoot, subdir)
+		if err != nil {
+			slog.Error("cannot create screen recording logger", "error", err)
+			return nil, false
+		}
+
+		uphookchain.append(ssh.InspectPacketHook(recorder.loggingTty))
+
+		return recorder.Close, true
+	}
+
+	return nil, true
+}
+
 func (d *daemon) run() error {
 	defer d.lis.Close()
 	slog.Info("sshpiperd is listening", "address", d.lis.Addr().String())
+
+	if err := d.initScreenRecording(); err != nil {
+		return err
+	}
+	if d.recordRoot != nil {
+		defer d.recordRoot.Close()
+	}
 
 	for {
 		conn, err := d.lis.Accept()
@@ -482,48 +596,12 @@ func (d *daemon) run() error {
 				downhookchain.append(sh.Down)
 			}
 
-			if d.recorddir != "" {
-				var recorddir string
-				if d.usernameAsRecorddir {
-					user := p.DownstreamConnMeta().User()
-					dir, serr := safeJoinUserRecordDir(d.recorddir, user)
-					if serr != nil {
-						slog.Error("invalid username for screen recording dir", "user", user, "error", serr)
-						return
-					}
-					recorddir = dir
-				} else {
-					uniqID := plugin.GetUniqueID(p.ChallengeContext())
-					recorddir = filepath.Join(d.recorddir, uniqID)
-				}
-				err = os.MkdirAll(recorddir, 0o700)
-				if err != nil {
-					slog.Error("cannot create screen recording dir", "recorddir", recorddir, "error", err)
-					return
-				}
-
-				switch d.recordfmt {
-				case "asciicast":
-					prefix := ""
-					if d.usernameAsRecorddir {
-						// add prefix to avoid conflict
-						prefix = fmt.Sprintf("%d-", time.Now().Unix())
-					}
-					recorder := newAsciicastLogger(recorddir, prefix)
-					defer recorder.Close()
-
-					uphookchain.append(ssh.InspectPacketHook(recorder.uphook))
-					downhookchain.append(ssh.InspectPacketHook(recorder.downhook))
-				case "typescript":
-					recorder, err := newFilePtyLogger(recorddir)
-					if err != nil {
-						slog.Error("cannot create screen recording logger", "error", err)
-						return
-					}
-					defer recorder.Close()
-
-					uphookchain.append(ssh.InspectPacketHook(recorder.loggingTty))
-				}
+			closeRecorder, ok := d.setupScreenRecording(p, uphookchain, downhookchain)
+			if !ok {
+				return
+			}
+			if closeRecorder != nil {
+				defer closeRecorder()
 			}
 
 			if d.filterHostkeysReqeust {

--- a/cmd/sshpiperd/record_e2e_test.go
+++ b/cmd/sshpiperd/record_e2e_test.go
@@ -13,66 +13,45 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// wireRecordingPiper replicates the screen-recording wiring in (*daemon).run
-// verbatim (including the path-traversal guard added for
-// --username-as-recorddir), so tests exercise the exact same code paths that
-// production traffic uses. It returns once the piped session ends, or
-// immediately if the recording dir is rejected (mirroring daemon.go's early
-// return).
+// wireRecordingPiper wires a single piped connection's screen-recording
+// hooks using (*daemon).setupScreenRecording, the exact same production
+// code path (*daemon).run uses, so these tests exercise the real wiring
+// rather than a copy of it. It returns once the piped session ends, or
+// immediately if the connection is rejected (mirroring daemon.go's
+// fail-closed behavior for screen recording).
 func wireRecordingPiper(t *testing.T, p *ssh.PiperConn, d *daemon) {
 	t.Helper()
 
 	uphookchain := &hookChain{}
 	downhookchain := &hookChain{}
 
-	if d.recorddir != "" {
-		var recorddir string
-		if d.usernameAsRecorddir {
-			user := p.DownstreamConnMeta().User()
-			dir, err := safeJoinUserRecordDir(d.recorddir, user)
-			if err != nil {
-				t.Logf("rejected screen recording dir for user %q: %v", user, err)
-				return
-			}
-			recorddir = dir
-		} else {
-			recorddir = filepath.Join(d.recorddir, "conn")
-		}
-
-		if err := os.MkdirAll(recorddir, 0o700); err != nil {
-			t.Errorf("cannot create screen recording dir: %v", err)
-			return
-		}
-
-		switch d.recordfmt {
-		case "asciicast":
-			recorder := newAsciicastLogger(recorddir, "")
-			defer recorder.Close()
-
-			uphookchain.append(ssh.InspectPacketHook(recorder.uphook))
-			downhookchain.append(ssh.InspectPacketHook(recorder.downhook))
-		case "typescript":
-			recorder, err := newFilePtyLogger(recorddir)
-			if err != nil {
-				t.Errorf("cannot create screen recording logger: %v", err)
-				return
-			}
-			defer recorder.Close()
-
-			uphookchain.append(ssh.InspectPacketHook(recorder.loggingTty))
-		}
+	closeRecorder, ok := d.setupScreenRecording(p, uphookchain, downhookchain)
+	if !ok {
+		t.Logf("screen recording setup rejected connection for user %q", p.DownstreamConnMeta().User())
+		return
+	}
+	if closeRecorder != nil {
+		defer closeRecorder()
 	}
 
 	_ = p.WaitWithHook(uphookchain.hook(), downhookchain.hook())
 }
 
-// startRecordingPiper starts the in-process sshpiper-style listener wired
-// exactly like daemon.go wires screen recording, proxying to an in-process
-// fake upstream sshd. It returns the piper listener address and a channel
-// that is closed once the (single) accepted connection's handling goroutine
-// has fully returned (including recorder.Close()).
+// startRecordingPiper starts the in-process sshpiper-style listener, wired
+// via (*daemon).initScreenRecording and (*daemon).setupScreenRecording --
+// the same production code paths (*daemon).run uses -- proxying to an
+// in-process fake upstream sshd. It returns the piper listener address and a
+// channel that is closed once the (single) accepted connection's handling
+// goroutine has fully returned (including recorder.Close()).
 func startRecordingPiper(t *testing.T, d *daemon) (addr string, done chan struct{}) {
 	t.Helper()
+
+	if err := d.initScreenRecording(); err != nil {
+		t.Fatalf("init screen recording: %v", err)
+	}
+	if d.recordRoot != nil {
+		t.Cleanup(func() { _ = d.recordRoot.Close() })
+	}
 
 	hostKey := genHostKey(t)
 
@@ -303,8 +282,8 @@ func TestDaemonScreenRecordingEndToEnd(t *testing.T) {
 // TestDaemonScreenRecordingRejectsPathTraversalUsername is a regression test
 // for the recorddir path-traversal fix: a malicious downstream username
 // containing ".." must not be able to make the per-user recording directory
-// resolve outside of the configured --record-*-dir root, and no directory or
-// recording file must be created as a result of the attempt.
+// resolve outside of the configured --screen-recording-dir root, and no
+// directory or recording file must be created as a result of the attempt.
 func TestDaemonScreenRecordingRejectsPathTraversalUsername(t *testing.T) {
 	recordParent := t.TempDir()
 	recordRoot := filepath.Join(recordParent, "records")
@@ -362,5 +341,68 @@ func TestDaemonScreenRecordingRejectsPathTraversalUsername(t *testing.T) {
 			names = append(names, e.Name())
 		}
 		t.Fatalf("recordRoot should remain empty, found: %v", names)
+	}
+}
+
+// TestDaemonScreenRecordingRejectsSymlinkEscape is a regression test for a
+// symlink-based escape that the lexical safeJoinUserRecordDir check alone
+// cannot catch: "evil" is a perfectly well-formed, non-traversing username,
+// so the lexical check happily accepts it. But if "evil" is actually a
+// symlink planted inside the recording root that points outside of it (e.g.
+// by another user with write access to the root, or as a leftover from a
+// previous, differently configured deployment), naively creating/opening
+// files by joining paths would follow that symlink and write outside the
+// configured --screen-recording-dir root.
+//
+// The real containment boundary is the os.Root opened on the recording root
+// in daemon.initScreenRecording (see setupScreenRecording): it refuses to
+// resolve any path -- including through a symlink -- to a location outside
+// of that root, so the connection must be rejected and nothing must be
+// written through the symlink.
+func TestDaemonScreenRecordingRejectsSymlinkEscape(t *testing.T) {
+	recordParent := t.TempDir()
+	recordRoot := filepath.Join(recordParent, "records")
+	if err := os.MkdirAll(recordRoot, 0o700); err != nil {
+		t.Fatalf("mkdir recordRoot: %v", err)
+	}
+
+	outside := filepath.Join(recordParent, "outside")
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+
+	// Plant a symlink inside recordRoot, named after the username we are
+	// about to use, whose relative target escapes recordRoot.
+	symlinkPath := filepath.Join(recordRoot, "evil")
+	if err := os.Symlink(filepath.Join("..", "outside"), symlinkPath); err != nil {
+		t.Skipf("cannot create symlink on this platform/privilege level: %v", err)
+	}
+
+	d := &daemon{
+		recorddir:           recordRoot,
+		recordfmt:           "asciicast",
+		usernameAsRecorddir: true,
+	}
+
+	addr, done := startRecordingPiper(t, d)
+
+	// As above, the piper handshake itself succeeds; the daemon only
+	// rejects once it tries to create the (symlinked) recording dir through
+	// recordRoot's os.Root. We only assert on what ended up on disk below.
+	_ = runClientShellSession(t, addr, "evil", "should-not-escape-via-symlink")
+
+	waitDone(t, done)
+
+	// Nothing should have been written into outside via the symlink.
+	outsideEntries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("read outside dir: %v", err)
+	}
+	if len(outsideEntries) != 0 {
+		names := make([]string, 0, len(outsideEntries))
+		for _, e := range outsideEntries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("recording escaped through symlink into %v, found: %v", outside, names)
 	}
 }

--- a/cmd/sshpiperd/record_e2e_test.go
+++ b/cmd/sshpiperd/record_e2e_test.go
@@ -1,0 +1,366 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// wireRecordingPiper replicates the screen-recording wiring in (*daemon).run
+// verbatim (including the path-traversal guard added for
+// --username-as-recorddir), so tests exercise the exact same code paths that
+// production traffic uses. It returns once the piped session ends, or
+// immediately if the recording dir is rejected (mirroring daemon.go's early
+// return).
+func wireRecordingPiper(t *testing.T, p *ssh.PiperConn, d *daemon) {
+	t.Helper()
+
+	uphookchain := &hookChain{}
+	downhookchain := &hookChain{}
+
+	if d.recorddir != "" {
+		var recorddir string
+		if d.usernameAsRecorddir {
+			user := p.DownstreamConnMeta().User()
+			dir, err := safeJoinUserRecordDir(d.recorddir, user)
+			if err != nil {
+				t.Logf("rejected screen recording dir for user %q: %v", user, err)
+				return
+			}
+			recorddir = dir
+		} else {
+			recorddir = filepath.Join(d.recorddir, "conn")
+		}
+
+		if err := os.MkdirAll(recorddir, 0o700); err != nil {
+			t.Errorf("cannot create screen recording dir: %v", err)
+			return
+		}
+
+		switch d.recordfmt {
+		case "asciicast":
+			recorder := newAsciicastLogger(recorddir, "")
+			defer recorder.Close()
+
+			uphookchain.append(ssh.InspectPacketHook(recorder.uphook))
+			downhookchain.append(ssh.InspectPacketHook(recorder.downhook))
+		case "typescript":
+			recorder, err := newFilePtyLogger(recorddir)
+			if err != nil {
+				t.Errorf("cannot create screen recording logger: %v", err)
+				return
+			}
+			defer recorder.Close()
+
+			uphookchain.append(ssh.InspectPacketHook(recorder.loggingTty))
+		}
+	}
+
+	_ = p.WaitWithHook(uphookchain.hook(), downhookchain.hook())
+}
+
+// startRecordingPiper starts the in-process sshpiper-style listener wired
+// exactly like daemon.go wires screen recording, proxying to an in-process
+// fake upstream sshd. It returns the piper listener address and a channel
+// that is closed once the (single) accepted connection's handling goroutine
+// has fully returned (including recorder.Close()).
+func startRecordingPiper(t *testing.T, d *daemon) (addr string, done chan struct{}) {
+	t.Helper()
+
+	hostKey := genHostKey(t)
+
+	upstreamLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("upstream listen: %v", err)
+	}
+	t.Cleanup(func() { upstreamLn.Close() })
+	go runFakeUpstream(t, upstreamLn, hostKey, make(chan envKV, 8))
+
+	piperLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("piper listen: %v", err)
+	}
+	t.Cleanup(func() { piperLn.Close() })
+
+	piperCfg := &ssh.PiperConfig{
+		NoClientAuthCallback: func(_ ssh.ConnMetadata, _ ssh.ChallengeContext) (*ssh.Upstream, error) {
+			c, err := net.Dial("tcp", upstreamLn.Addr().String())
+			if err != nil {
+				return nil, err
+			}
+			return &ssh.Upstream{
+				Conn: c,
+				ClientConfig: ssh.ClientConfig{
+					User:            "u",
+					Auth:            []ssh.AuthMethod{ssh.NoneAuth()},
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+				},
+			}, nil
+		},
+	}
+	piperCfg.AddHostKey(hostKey)
+
+	done = make(chan struct{})
+	go func() {
+		defer close(done)
+
+		c, err := piperLn.Accept()
+		if err != nil {
+			return
+		}
+
+		p, err := ssh.NewSSHPiperConn(c, piperCfg)
+		if err != nil {
+			t.Errorf("piper handshake: %v", err)
+			return
+		}
+		defer p.Close()
+
+		wireRecordingPiper(t, p, d)
+	}()
+
+	return piperLn.Addr().String(), done
+}
+
+// runClientShellSession dials addr as user, opens a shell session, writes
+// payload to stdin, drains stdout, and closes the connection. It is used to
+// drive traffic through the recording hooks the same way a real SSH client
+// would.
+func runClientShellSession(t *testing.T, addr, user, payload string) error {
+	t.Helper()
+
+	conn, err := ssh.Dial("tcp", addr, &ssh.ClientConfig{
+		User:            user,
+		Auth:            []ssh.AuthMethod{ssh.NoneAuth()},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	session, err := conn.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	if err := session.Shell(); err != nil {
+		return err
+	}
+
+	_, _ = stdin.Write([]byte(payload))
+	stdin.Close()
+	_, _ = io.ReadAll(stdout)
+
+	return nil
+}
+
+func waitDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server-side connection handler to finish")
+	}
+}
+
+// TestDaemonScreenRecordingEndToEnd verifies that, wired exactly the way
+// daemon.go wires it, a real shell session typed by a client is actually
+// captured on disk under recorddir/<username>/ for both supported formats.
+func TestDaemonScreenRecordingEndToEnd(t *testing.T) {
+	const payload = "hello-recording-e2e"
+
+	t.Run("asciicast", func(t *testing.T) {
+		recordRoot := t.TempDir()
+		d := &daemon{
+			recorddir:           recordRoot,
+			recordfmt:           "asciicast",
+			usernameAsRecorddir: true,
+		}
+
+		addr, done := startRecordingPiper(t, d)
+
+		if err := runClientShellSession(t, addr, "alice", payload); err != nil {
+			t.Fatalf("client session: %v", err)
+		}
+		waitDone(t, done)
+
+		userDir := filepath.Join(recordRoot, "alice")
+		entries, err := os.ReadDir(userDir)
+		if err != nil {
+			t.Fatalf("read user record dir: %v", err)
+		}
+
+		var castFile string
+		for _, e := range entries {
+			if strings.HasSuffix(e.Name(), ".cast") {
+				castFile = filepath.Join(userDir, e.Name())
+			}
+		}
+		if castFile == "" {
+			t.Fatalf("no .cast file found in %v, entries: %v", userDir, entries)
+		}
+
+		content, err := os.ReadFile(castFile)
+		if err != nil {
+			t.Fatalf("read cast file: %v", err)
+		}
+
+		lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+		if len(lines) < 1 {
+			t.Fatalf("cast file has no lines: %q", content)
+		}
+
+		var header struct {
+			Version int `json:"version"`
+			Width   int `json:"width"`
+			Height  int `json:"height"`
+		}
+		if err := json.Unmarshal([]byte(lines[0]), &header); err != nil {
+			t.Fatalf("cast header not valid json: %v (line=%q)", err, lines[0])
+		}
+		if header.Version != 2 {
+			t.Errorf("cast header version = %d, want 2", header.Version)
+		}
+
+		if !strings.Contains(string(content), payload) {
+			t.Errorf("cast file does not contain typed payload %q; content: %q", payload, content)
+		}
+	})
+
+	t.Run("typescript", func(t *testing.T) {
+		recordRoot := t.TempDir()
+		d := &daemon{
+			recorddir:           recordRoot,
+			recordfmt:           "typescript",
+			usernameAsRecorddir: true,
+		}
+
+		addr, done := startRecordingPiper(t, d)
+
+		if err := runClientShellSession(t, addr, "bob", payload); err != nil {
+			t.Fatalf("client session: %v", err)
+		}
+		waitDone(t, done)
+
+		userDir := filepath.Join(recordRoot, "bob")
+		entries, err := os.ReadDir(userDir)
+		if err != nil {
+			t.Fatalf("read user record dir: %v", err)
+		}
+
+		var typescriptFile, timingFile string
+		for _, e := range entries {
+			switch {
+			case strings.HasSuffix(e.Name(), ".typescript"):
+				typescriptFile = filepath.Join(userDir, e.Name())
+			case strings.HasSuffix(e.Name(), ".timing"):
+				timingFile = filepath.Join(userDir, e.Name())
+			}
+		}
+		if typescriptFile == "" || timingFile == "" {
+			t.Fatalf("expected .typescript and .timing files in %v, entries: %v", userDir, entries)
+		}
+
+		content, err := os.ReadFile(typescriptFile)
+		if err != nil {
+			t.Fatalf("read typescript file: %v", err)
+		}
+		if !strings.Contains(string(content), payload) {
+			t.Errorf("typescript file does not contain typed payload %q; content: %q", payload, content)
+		}
+		if !strings.Contains(string(content), "Script started on") || !strings.Contains(string(content), "Script done on") {
+			t.Errorf("typescript file missing script start/done banners: %q", content)
+		}
+
+		timing, err := os.ReadFile(timingFile)
+		if err != nil {
+			t.Fatalf("read timing file: %v", err)
+		}
+		if len(strings.TrimSpace(string(timing))) == 0 {
+			t.Errorf("timing file is empty, want at least one timing entry")
+		}
+	})
+}
+
+// TestDaemonScreenRecordingRejectsPathTraversalUsername is a regression test
+// for the recorddir path-traversal fix: a malicious downstream username
+// containing ".." must not be able to make the per-user recording directory
+// resolve outside of the configured --record-*-dir root, and no directory or
+// recording file must be created as a result of the attempt.
+func TestDaemonScreenRecordingRejectsPathTraversalUsername(t *testing.T) {
+	recordParent := t.TempDir()
+	recordRoot := filepath.Join(recordParent, "records")
+	if err := os.MkdirAll(recordRoot, 0o700); err != nil {
+		t.Fatalf("mkdir recordRoot: %v", err)
+	}
+
+	maliciousUsers := []string{
+		"../../evil",
+		"..",
+		"../outside",
+	}
+
+	for _, user := range maliciousUsers {
+		d := &daemon{
+			recorddir:           recordRoot,
+			recordfmt:           "asciicast",
+			usernameAsRecorddir: true,
+		}
+
+		addr, done := startRecordingPiper(t, d)
+
+		// The SSH/piper handshake itself succeeds (auth is NoClientAuth);
+		// the daemon only rejects once it resolves the recording dir, so a
+		// dial error here is not expected, but session I/O may fail once the
+		// server tears the connection down. Either way we only assert on
+		// what ended up on disk below.
+		_ = runClientShellSession(t, addr, user, "should-not-be-recorded")
+
+		waitDone(t, done)
+	}
+
+	// Nothing should have escaped into the parent of recordRoot.
+	parentEntries, err := os.ReadDir(recordParent)
+	if err != nil {
+		t.Fatalf("read record parent dir: %v", err)
+	}
+	if len(parentEntries) != 1 || parentEntries[0].Name() != filepath.Base(recordRoot) {
+		names := make([]string, 0, len(parentEntries))
+		for _, e := range parentEntries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("unexpected entries escaped into parent of recordRoot: %v", names)
+	}
+
+	// And nothing should have been created inside recordRoot either, since
+	// every attempted username was rejected before mkdir/recording started.
+	rootEntries, err := os.ReadDir(recordRoot)
+	if err != nil {
+		t.Fatalf("read recordRoot: %v", err)
+	}
+	if len(rootEntries) != 0 {
+		names := make([]string, 0, len(rootEntries))
+		for _, e := range rootEntries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("recordRoot should remain empty, found: %v", names)
+	}
+}

--- a/cmd/sshpiperd/recorddir_test.go
+++ b/cmd/sshpiperd/recorddir_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestSafeJoinUserRecordDir exercises the path-traversal guard that protects
+// --record-typescript-dir / --record-asciicast-dir when
+// --username-as-recorddir is enabled. The downstream SSH username is fully
+// attacker-controlled, so a malicious user string must never be able to
+// resolve outside of the configured recording root.
+func TestSafeJoinUserRecordDir(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "records")
+
+	tests := []struct {
+		name    string
+		user    string
+		wantErr bool
+	}{
+		{name: "plain username", user: "alice", wantErr: false},
+		{name: "username with subdirs stays inside", user: "alice/bob", wantErr: false},
+		{name: "empty username resolves to base", user: "", wantErr: false},
+		{name: "dot username resolves to base", user: ".", wantErr: false},
+		{name: "parent traversal", user: "..", wantErr: true},
+		{name: "nested parent traversal", user: "../../etc/passwd", wantErr: true},
+		{name: "traversal after subdir", user: "foo/../../bar", wantErr: true},
+		{name: "traversal disguised with valid prefix", user: "alice/../../evil", wantErr: true},
+		{name: "absolute path escapes via join", user: "/etc/passwd", wantErr: false}, // filepath.Join treats it as relative to base
+		{name: "leading slashes still relative", user: "//../../evil", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, err := safeJoinUserRecordDir(base, tt.user)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("safeJoinUserRecordDir(%q, %q) = %q, nil; want error", base, tt.user, dir)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("safeJoinUserRecordDir(%q, %q) unexpected error: %v", base, tt.user, err)
+			}
+
+			rel, rerr := filepath.Rel(base, dir)
+			if rerr != nil {
+				t.Fatalf("filepath.Rel(%q, %q) error: %v", base, dir, rerr)
+			}
+			if rel == ".." || (len(rel) >= 3 && rel[:3] == ".."+string(filepath.Separator)) {
+				t.Fatalf("safeJoinUserRecordDir(%q, %q) = %q escapes base %q (rel=%q)", base, tt.user, dir, base, rel)
+			}
+		})
+	}
+}

--- a/cmd/sshpiperd/recorddir_test.go
+++ b/cmd/sshpiperd/recorddir_test.go
@@ -2,14 +2,21 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-// TestSafeJoinUserRecordDir exercises the path-traversal guard that protects
-// --record-typescript-dir / --record-asciicast-dir when
-// --username-as-recorddir is enabled. The downstream SSH username is fully
-// attacker-controlled, so a malicious user string must never be able to
-// resolve outside of the configured recording root.
+// TestSafeJoinUserRecordDir exercises the lexical path-traversal guard that
+// protects the per-user recording subdirectory created under
+// --screen-recording-dir when --username-as-recorddir is enabled. The
+// downstream SSH username is fully attacker-controlled, so a malicious user
+// string must never resolve outside of the configured recording root.
+//
+// This lexical guard is only a first line of defense: the subdirectory name
+// it returns is always subsequently created/opened through an os.Root
+// scoped to the recording root (see daemon.initScreenRecording /
+// setupScreenRecording), which is the actual containment boundary and also
+// refuses to follow a symlink that would escape the root.
 func TestSafeJoinUserRecordDir(t *testing.T) {
 	base := filepath.Join(t.TempDir(), "records")
 
@@ -26,16 +33,16 @@ func TestSafeJoinUserRecordDir(t *testing.T) {
 		{name: "nested parent traversal", user: "../../etc/passwd", wantErr: true},
 		{name: "traversal after subdir", user: "foo/../../bar", wantErr: true},
 		{name: "traversal disguised with valid prefix", user: "alice/../../evil", wantErr: true},
-		{name: "absolute path escapes via join", user: "/etc/passwd", wantErr: false}, // filepath.Join treats it as relative to base
+		{name: "absolute-looking username stays contained under base", user: "/etc/passwd", wantErr: false}, // filepath.Join treats it as relative to base, so it does not escape
 		{name: "leading slashes still relative", user: "//../../evil", wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := safeJoinUserRecordDir(base, tt.user)
+			rel, err := safeJoinUserRecordDir(base, tt.user)
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("safeJoinUserRecordDir(%q, %q) = %q, nil; want error", base, tt.user, dir)
+					t.Fatalf("safeJoinUserRecordDir(%q, %q) = %q, nil; want error", base, tt.user, rel)
 				}
 				return
 			}
@@ -44,12 +51,15 @@ func TestSafeJoinUserRecordDir(t *testing.T) {
 				t.Fatalf("safeJoinUserRecordDir(%q, %q) unexpected error: %v", base, tt.user, err)
 			}
 
-			rel, rerr := filepath.Rel(base, dir)
-			if rerr != nil {
-				t.Fatalf("filepath.Rel(%q, %q) error: %v", base, dir, rerr)
+			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				t.Fatalf("safeJoinUserRecordDir(%q, %q) = %q escapes base %q", base, tt.user, rel, base)
 			}
-			if rel == ".." || (len(rel) >= 3 && rel[:3] == ".."+string(filepath.Separator)) {
-				t.Fatalf("safeJoinUserRecordDir(%q, %q) = %q escapes base %q (rel=%q)", base, tt.user, dir, base, rel)
+
+			// The returned name must be relative to base, and joining it
+			// back onto base must stay inside base.
+			joined := filepath.Join(base, rel)
+			if !strings.HasPrefix(joined+string(filepath.Separator), filepath.Clean(base)+string(filepath.Separator)) {
+				t.Fatalf("safeJoinUserRecordDir(%q, %q) = %q joins outside base %q", base, tt.user, rel, base)
 			}
 		})
 	}

--- a/cmd/sshpiperd/typescript.go
+++ b/cmd/sshpiperd/typescript.go
@@ -18,12 +18,17 @@ type filePtyLogger struct {
 	oldtime time.Time
 }
 
-func newFilePtyLogger(outputdir string) (*filePtyLogger, error) {
+// newFilePtyLogger creates a recorder that writes .typescript/.timing files
+// under outputdir, a subdirectory name relative to root. root is opened on
+// the configured screen recording root (see daemon.recordRoot); every file
+// this logger opens goes through root.OpenFile so that even if outputdir
+// contains a symlink planted by an attacker, the write cannot escape root.
+func newFilePtyLogger(root *os.Root, outputdir string) (*filePtyLogger, error) {
 	now := time.Now()
 
 	filename := fmt.Sprintf("%d", now.Unix())
 
-	typescript, err := os.OpenFile(path.Join(outputdir, fmt.Sprintf("%v.typescript", filename)), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	typescript, err := root.OpenFile(path.Join(outputdir, fmt.Sprintf("%v.typescript", filename)), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +38,7 @@ func newFilePtyLogger(outputdir string) (*filePtyLogger, error) {
 		return nil, err
 	}
 
-	timing, err := os.OpenFile(path.Join(outputdir, fmt.Sprintf("%v.timing", filename)), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	timing, err := root.OpenFile(path.Join(outputdir, fmt.Sprintf("%v.timing", filename)), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/screenrecording_test.go
+++ b/e2e/screenrecording_test.go
@@ -1,0 +1,313 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/ssh"
+)
+
+// createFakeEchoSshServer starts a minimal in-process SSH server (reusing
+// the same test host key as createFakeSshServer in grpcplugin_test.go) that
+// accepts any username/password and echoes back any data written to a
+// "session" channel. It stands in for a real upstream sshd so the screen
+// recording e2e tests do not depend on a real system user account and can
+// freely use arbitrary — including malicious, path-traversal-attempting —
+// downstream usernames.
+func createFakeEchoSshServer(t *testing.T) net.Listener {
+	t.Helper()
+
+	config := &ssh.ServerConfig{
+		PasswordCallback: func(_ ssh.ConnMetadata, _ []byte) (*ssh.Permissions, error) {
+			return nil, nil
+		},
+	}
+	config.SetDefaults()
+	private, err := ssh.ParsePrivateKey([]byte(testprivatekey))
+	if err != nil {
+		t.Fatalf("failed to parse test private key: %v", err)
+	}
+	config.AddHostKey(private)
+
+	l, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatalf("failed to listen for fake upstream: %v", err)
+	}
+	t.Cleanup(func() { l.Close() })
+
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+
+			go func(c net.Conn) {
+				defer c.Close()
+
+				_, chans, reqs, err := ssh.NewServerConn(c, config)
+				if err != nil {
+					return
+				}
+				go ssh.DiscardRequests(reqs)
+
+				for nc := range chans {
+					if nc.ChannelType() != "session" {
+						_ = nc.Reject(ssh.UnknownChannelType, "")
+						continue
+					}
+
+					ch, in, err := nc.Accept()
+					if err != nil {
+						continue
+					}
+
+					go func(in <-chan *ssh.Request) {
+						for req := range in {
+							if req.WantReply {
+								_ = req.Reply(true, nil)
+							}
+						}
+					}(in)
+
+					// Echo: whatever the client writes to the channel
+					// (stdin) is written straight back on the same channel
+					// (stdout), exactly like the fake upstream used in the
+					// unit-level e2e test in cmd/sshpiperd. This is what
+					// makes the recorded output deterministic and
+					// verifiable from the client side.
+					go func(ch ssh.Channel) {
+						defer ch.Close()
+						_, _ = io.Copy(ch, ch)
+					}(ch)
+				}
+			}(c)
+		}
+	}()
+
+	return l
+}
+
+// recordingSession dials piperAddr as user (which may be a malicious,
+// path-traversal-attempting username) through the real sshpiperd binary,
+// opens a shell session, writes payload to it, and waits for the upstream
+// echo server to reflect it back — proving the recording hooks observed
+// live traffic, not just the request. Every step tolerates errors: when the
+// daemon intentionally tears down the connection (e.g. it rejects the
+// username for recording), dial/session/shell calls are expected to fail or
+// hang up early, and callers only care about what ends up on disk.
+func recordingSession(t *testing.T, piperAddr, user, payload string) {
+	t.Helper()
+
+	client, err := ssh.Dial("tcp", piperAddr, &ssh.ClientConfig{
+		User:            user,
+		Auth:            []ssh.AuthMethod{ssh.Password("anypass")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         waitTimeout,
+	})
+	if err != nil {
+		t.Logf("dial piper as %q: %v (may be expected)", user, err)
+		return
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Logf("new session as %q: %v (may be expected)", user, err)
+		return
+	}
+	defer session.Close()
+
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		t.Logf("stdin pipe as %q: %v", user, err)
+		return
+	}
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		t.Logf("stdout pipe as %q: %v", user, err)
+		return
+	}
+
+	if err := session.Shell(); err != nil {
+		t.Logf("shell as %q: %v (may be expected)", user, err)
+		return
+	}
+
+	_, _ = stdin.Write([]byte(payload))
+	_ = stdin.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.ReadAll(stdout)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(waitTimeout):
+	}
+}
+
+// findFileWithSuffix walks dir looking for the first regular file whose
+// name has the given suffix, returning its path and content. It fails the
+// test if none is found.
+func findFileWithSuffix(t *testing.T, dir, suffix string) (path, content string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %v: %v", dir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), suffix) {
+			continue
+		}
+		p := filepath.Join(dir, e.Name())
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read file %v: %v", p, err)
+		}
+		return p, string(b)
+	}
+	t.Fatalf("no *%v file found in %v, entries: %v", suffix, dir, entries)
+	return "", ""
+}
+
+// TestScreenRecordingE2E starts the real sshpiperd binary (not an
+// in-process stub), wired with --screen-recording-dir /
+// --screen-recording-format / --username-as-recorddir exactly as an operator
+// would configure it, drives an actual SSH session against it with the
+// golang.org/x/crypto/ssh client library, and asserts that the
+// typed/echoed session content is genuinely captured to disk, for both
+// supported recording formats.
+func TestScreenRecordingE2E(t *testing.T) {
+	upstream := createFakeEchoSshServer(t)
+
+	for _, format := range []string{"asciicast", "typescript"} {
+		t.Run(format, func(t *testing.T) {
+			recordDir := t.TempDir()
+			piperaddr, piperport := nextAvailablePiperAddress()
+
+			piper, _, _, err := runCmd("/sshpiperd/sshpiperd",
+				"-p", piperport,
+				"--screen-recording-dir", recordDir,
+				"--screen-recording-format", format,
+				"--username-as-recorddir",
+				"/sshpiperd/plugins/fixed",
+				"--target", upstream.Addr().String(),
+			)
+			if err != nil {
+				t.Fatalf("failed to run sshpiperd: %v", err)
+			}
+			t.Cleanup(func() { killCmd(piper) })
+			waitForEndpointReady(piperaddr)
+
+			user := "user-" + uuid.New().String()[:8]
+			payload := "hello-" + uuid.New().String()
+
+			recordingSession(t, piperaddr, user, payload)
+
+			// Give the recorder time to flush/close its files after the
+			// session ends.
+			time.Sleep(time.Second)
+
+			userDir := filepath.Join(recordDir, user)
+			var suffix string
+			switch format {
+			case "asciicast":
+				suffix = ".cast"
+			case "typescript":
+				suffix = ".typescript"
+			}
+
+			_, content := findFileWithSuffix(t, userDir, suffix)
+			if !strings.Contains(content, payload) {
+				t.Errorf("recording does not contain payload %q; content: %q", payload, content)
+			}
+
+			if format == "asciicast" {
+				lines := strings.SplitN(strings.TrimSpace(content), "\n", 2)
+				var header struct {
+					Version int `json:"version"`
+				}
+				if err := json.Unmarshal([]byte(lines[0]), &header); err != nil {
+					t.Errorf("cast header not valid json: %v (line=%q)", err, lines[0])
+				} else if header.Version != 2 {
+					t.Errorf("cast header version = %d, want 2", header.Version)
+				}
+			}
+		})
+	}
+}
+
+// TestScreenRecordingPathTraversalE2E is the end-to-end regression test for
+// the recorddir path-traversal fix: it drives real SSH sessions with
+// malicious, path-traversal-attempting usernames through the actual
+// sshpiperd binary with --username-as-recorddir enabled, and asserts that
+// no file or directory is ever created outside of the configured recording
+// root as a result.
+func TestScreenRecordingPathTraversalE2E(t *testing.T) {
+	upstream := createFakeEchoSshServer(t)
+
+	recordParent := t.TempDir()
+	recordDir := filepath.Join(recordParent, "records")
+	if err := os.MkdirAll(recordDir, 0o700); err != nil {
+		t.Fatalf("mkdir recordDir: %v", err)
+	}
+
+	piperaddr, piperport := nextAvailablePiperAddress()
+
+	piper, _, _, err := runCmd("/sshpiperd/sshpiperd",
+		"-p", piperport,
+		"--screen-recording-dir", recordDir,
+		"--screen-recording-format", "asciicast",
+		"--username-as-recorddir",
+		"/sshpiperd/plugins/fixed",
+		"--target", upstream.Addr().String(),
+	)
+	if err != nil {
+		t.Fatalf("failed to run sshpiperd: %v", err)
+	}
+	t.Cleanup(func() { killCmd(piper) })
+	waitForEndpointReady(piperaddr)
+
+	for _, user := range []string{"../evil", "..", "../../outside"} {
+		recordingSession(t, piperaddr, user, "should-not-be-recorded")
+	}
+
+	// Give the daemon time to react (mkdir attempt / rejection) after each
+	// session tears down.
+	time.Sleep(time.Second)
+
+	parentEntries, err := os.ReadDir(recordParent)
+	if err != nil {
+		t.Fatalf("read record parent dir: %v", err)
+	}
+	if len(parentEntries) != 1 || parentEntries[0].Name() != filepath.Base(recordDir) {
+		names := make([]string, 0, len(parentEntries))
+		for _, e := range parentEntries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("unexpected entries escaped into parent of recordDir: %v", names)
+	}
+
+	rootEntries, err := os.ReadDir(recordDir)
+	if err != nil {
+		t.Fatalf("read recordDir: %v", err)
+	}
+	if len(rootEntries) != 0 {
+		names := make([]string, 0, len(rootEntries))
+		for _, e := range rootEntries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("recordDir should remain empty, found: %v", names)
+	}
+}


### PR DESCRIPTION
## Summary

When screen recording is enabled with both \--screen-recording-dir\ and \--username-as-recorddir\, the recording directory was built as \path.Join(recorddir, DownstreamConnMeta().User())\. Since the downstream SSH username is arbitrary, a value containing \..\ segments could resolve outside the configured recording root.

## Changes

- \cmd/sshpiperd/daemon.go\: switch to \ilepath.Join\ and verify with \ilepath.Rel\ that the resulting recording directory stays within the configured recording root; reject usernames that would resolve outside it.

## Testing

- \go build ./...\ in \cmd/sshpiperd\ passes.
- \gofumpt -l\ reports the file clean.