### PR TITLE
yaml plugin: sanitize path placeholders and fail closed on empty known_hosts

### DIFF
--- a/plugin/yaml/skel.go
+++ b/plugin/yaml/skel.go
@@ -79,10 +79,24 @@ func (s *skelpipeToWrapper) Host(conn libplugin.ConnMetadata) string {
 }
 
 func (s *skelpipeToWrapper) KnownHosts(conn libplugin.ConnMetadata) ([]byte, error) {
-	return s.config.loadFileOrDecodeMany(s.to.KnownHosts, s.to.KnownHostsData, map[string]string{
+	configured := s.to.KnownHosts.Any() || s.to.KnownHostsData.Any()
+
+	data, err := s.config.loadFileOrDecodeMany(s.to.KnownHosts, s.to.KnownHostsData, map[string]string{
 		"DOWNSTREAM_USER": conn.User(),
 		"UPSTREAM_USER":   s.username,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	// known_hosts was configured but resolved to no data (e.g. missing file).
+	// Treat this as a hard failure instead of silently falling back to
+	// disabling upstream host key verification.
+	if configured && len(data) == 0 {
+		return nil, fmt.Errorf("known_hosts is configured for upstream user %q but resolved to no data", s.username)
+	}
+
+	return data, nil
 }
 
 func (s *skelpipeFromWrapper) MatchConn(conn libplugin.ConnMetadata) (skel.SkelPipeTo, error) {

--- a/plugin/yaml/skel.go
+++ b/plugin/yaml/skel.go
@@ -79,7 +79,7 @@ func (s *skelpipeToWrapper) Host(conn libplugin.ConnMetadata) string {
 }
 
 func (s *skelpipeToWrapper) KnownHosts(conn libplugin.ConnMetadata) ([]byte, error) {
-	configured := s.to.KnownHosts.Any() || s.to.KnownHostsData.Any()
+	configured := s.to.KnownHosts.Configured() || s.to.KnownHostsData.Configured()
 
 	data, err := s.config.loadFileOrDecodeMany(s.to.KnownHosts, s.to.KnownHostsData, map[string]string{
 		"DOWNSTREAM_USER": conn.User(),

--- a/plugin/yaml/yaml.go
+++ b/plugin/yaml/yaml.go
@@ -41,10 +41,22 @@ type yamlPipeTo struct {
 type listOrString struct {
 	List []string
 	Str  string
+
+	// present records whether this field was explicitly set in the YAML
+	// document, even to an empty string or an empty list. This is distinct
+	// from Any(), which only reflects whether there is non-empty data.
+	present bool
 }
 
 func (l *listOrString) Any() bool {
 	return len(l.List) > 0 || l.Str != ""
+}
+
+// Configured reports whether the field should be treated as configured: either
+// it carries actual data, or it was explicitly present in the YAML document
+// (even set to an empty string or an empty list).
+func (l *listOrString) Configured() bool {
+	return l.present || l.Any()
 }
 
 func (l *listOrString) Combine() []string {
@@ -55,6 +67,8 @@ func (l *listOrString) Combine() []string {
 }
 
 func (l *listOrString) UnmarshalYAML(value *yaml.Node) error {
+	l.present = true
+
 	// Try to unmarshal as a list
 	var list []string
 	if err := value.Decode(&list); err == nil {
@@ -166,20 +180,24 @@ func isPathSafeValue(v string) bool {
 func (p *piperConfig) loadFileOrDecode(file string, base64data string, vars map[string]string) ([]byte, error) {
 	if file != "" {
 
-		for name, v := range vars {
-			if !isPathSafeValue(v) {
-				return nil, fmt.Errorf("value of placeholder %v is not allowed to be used in a path: %q", name, v)
-			}
-		}
+		var expandErr error
 
 		file = os.Expand(file, func(placeholderName string) string {
 			v, ok := vars[placeholderName]
-			if ok {
-				return v
+			if !ok {
+				return os.Getenv(placeholderName)
 			}
 
-			return os.Getenv(placeholderName)
+			if expandErr == nil && !isPathSafeValue(v) {
+				expandErr = fmt.Errorf("value of placeholder %v is not allowed to be used in a path: %q", placeholderName, v)
+			}
+
+			return v
 		})
+
+		if expandErr != nil {
+			return nil, expandErr
+		}
 
 		if !filepath.IsAbs(file) {
 			file = filepath.Join(filepath.Dir(p.filename), file)

--- a/plugin/yaml/yaml.go
+++ b/plugin/yaml/yaml.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
@@ -150,8 +151,26 @@ func (p *plugin) loadConfig() ([]piperConfig, error) {
 	return allconfig, nil
 }
 
+// isPathSafeValue rejects values that could be used to escape the directory
+// a path placeholder is expanded into, e.g. an SSH username of "../../etc".
+func isPathSafeValue(v string) bool {
+	if strings.ContainsAny(v, `/\`) {
+		return false
+	}
+	if v == ".." || v == "." {
+		return false
+	}
+	return true
+}
+
 func (p *piperConfig) loadFileOrDecode(file string, base64data string, vars map[string]string) ([]byte, error) {
 	if file != "" {
+
+		for name, v := range vars {
+			if !isPathSafeValue(v) {
+				return nil, fmt.Errorf("value of placeholder %v is not allowed to be used in a path: %q", name, v)
+			}
+		}
 
 		file = os.Expand(file, func(placeholderName string) string {
 			v, ok := vars[placeholderName]

--- a/plugin/yaml/yaml_test.go
+++ b/plugin/yaml/yaml_test.go
@@ -197,6 +197,29 @@ func TestLoadFileOrDecodeRejectsPathTraversal(t *testing.T) {
 	}
 }
 
+func TestLoadFileOrDecodeIgnoresUnreferencedPlaceholder(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	p := piperConfig{filename: configPath}
+
+	// A static path does not reference DOWNSTREAM_USER, so an unsafe value
+	// for that placeholder must not cause validation to fail.
+	staticFile := filepath.Join(dir, "known_hosts")
+	if err := os.WriteFile(staticFile, []byte("static-data"), 0o600); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	data, err := p.loadFileOrDecode(staticFile, "", map[string]string{
+		"DOWNSTREAM_USER": "../../../etc/passwd",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error for unreferenced placeholder: %v", err)
+	}
+	if string(data) != "static-data" {
+		t.Fatalf("Expected file contents, got %q", string(data))
+	}
+}
+
 func TestCheckPerm(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
@@ -341,6 +364,64 @@ func TestKnownHostsNotConfiguredSucceeds(t *testing.T) {
 	}
 	if len(data) != 0 {
 		t.Fatalf("Expected no data, got %q", data)
+	}
+}
+
+func TestKnownHostsExplicitEmptyStringFails(t *testing.T) {
+	var to yamlPipeTo
+	if err := yaml.Unmarshal([]byte(`
+host: example.com:22
+username: user
+known_hosts: ""
+`), &to); err != nil {
+		t.Fatalf("Failed to unmarshal config: %v", err)
+	}
+
+	if !to.KnownHosts.Configured() {
+		t.Fatalf("Expected explicit empty known_hosts string to be considered configured")
+	}
+
+	config := &piperConfig{filename: filepath.Join(t.TempDir(), "config.yaml")}
+	wrapper := &skelpipeToWrapper{config: config, username: "user", to: &to}
+
+	if _, err := wrapper.KnownHosts(fakeConn{user: "alice"}); err == nil {
+		t.Fatalf("Expected error when known_hosts is explicitly configured to an empty string")
+	}
+}
+
+func TestKnownHostsExplicitEmptyListFails(t *testing.T) {
+	var to yamlPipeTo
+	if err := yaml.Unmarshal([]byte(`
+host: example.com:22
+username: user
+known_hosts_data: []
+`), &to); err != nil {
+		t.Fatalf("Failed to unmarshal config: %v", err)
+	}
+
+	if !to.KnownHostsData.Configured() {
+		t.Fatalf("Expected explicit empty known_hosts_data list to be considered configured")
+	}
+
+	config := &piperConfig{filename: filepath.Join(t.TempDir(), "config.yaml")}
+	wrapper := &skelpipeToWrapper{config: config, username: "user", to: &to}
+
+	if _, err := wrapper.KnownHosts(fakeConn{user: "alice"}); err == nil {
+		t.Fatalf("Expected error when known_hosts_data is explicitly configured to an empty list")
+	}
+}
+
+func TestKnownHostsFieldOmittedNotConfigured(t *testing.T) {
+	var to yamlPipeTo
+	if err := yaml.Unmarshal([]byte(`
+host: example.com:22
+username: user
+`), &to); err != nil {
+		t.Fatalf("Failed to unmarshal config: %v", err)
+	}
+
+	if to.KnownHosts.Configured() || to.KnownHostsData.Configured() {
+		t.Fatalf("Expected omitted known_hosts fields to not be considered configured")
 	}
 }
 

--- a/plugin/yaml/yaml_test.go
+++ b/plugin/yaml/yaml_test.go
@@ -159,6 +159,44 @@ func TestLoadFileOrDecodeMany(t *testing.T) {
 	}
 }
 
+func TestLoadFileOrDecodeRejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	p := piperConfig{filename: configPath}
+
+	tests := []string{
+		"../../../etc/passwd",
+		"..",
+		"foo/../bar",
+		`foo\bar`,
+		"foo/bar",
+	}
+
+	for _, malicious := range tests {
+		_, err := p.loadFileOrDecode("keys_$DOWNSTREAM_USER.txt", "", map[string]string{
+			"DOWNSTREAM_USER": malicious,
+		})
+		if err == nil {
+			t.Fatalf("Expected error for malicious placeholder value %q, got nil", malicious)
+		}
+	}
+
+	// a normal username must still work
+	filePath := filepath.Join(dir, "keys_alice.txt")
+	if err := os.WriteFile(filePath, []byte("file-data"), 0o600); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	data, err := p.loadFileOrDecode("keys_$DOWNSTREAM_USER.txt", "", map[string]string{
+		"DOWNSTREAM_USER": "alice",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error for benign username: %v", err)
+	}
+	if string(data) != "file-data" {
+		t.Fatalf("Expected file contents, got %q", string(data))
+	}
+}
+
 func TestCheckPerm(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
@@ -266,6 +304,43 @@ func TestSkelPipeWrapperFrom(t *testing.T) {
 	}
 	if _, ok := froms[1].(*skelpipePublicKeyWrapper); !ok {
 		t.Fatalf("Expected public key wrapper, got %T", froms[1])
+	}
+}
+
+func TestKnownHostsConfiguredButEmptyFails(t *testing.T) {
+	dir := t.TempDir()
+	emptyPath := filepath.Join(dir, "known_hosts")
+	if err := os.WriteFile(emptyPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("Failed to write empty known_hosts: %v", err)
+	}
+
+	config := &piperConfig{filename: filepath.Join(dir, "config.yaml")}
+	to := &yamlPipeTo{
+		Host:       "example.com:22",
+		Username:   "user",
+		KnownHosts: listOrString{Str: "known_hosts"},
+	}
+	wrapper := &skelpipeToWrapper{config: config, username: "user", to: to}
+
+	if _, err := wrapper.KnownHosts(fakeConn{user: "alice"}); err == nil {
+		t.Fatalf("Expected error when known_hosts is configured but resolves to no data")
+	}
+}
+
+func TestKnownHostsNotConfiguredSucceeds(t *testing.T) {
+	config := &piperConfig{filename: filepath.Join(t.TempDir(), "config.yaml")}
+	to := &yamlPipeTo{
+		Host:     "example.com:22",
+		Username: "user",
+	}
+	wrapper := &skelpipeToWrapper{config: config, username: "user", to: to}
+
+	data, err := wrapper.KnownHosts(fakeConn{user: "alice"})
+	if err != nil {
+		t.Fatalf("Unexpected error when known_hosts is not configured: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("Expected no data, got %q", data)
 	}
 }
 


### PR DESCRIPTION
## What
- `$DOWNSTREAM_USER` / `$UPSTREAM_USER` placeholders used when resolving `private_key`, `authorized_keys`, `trusted_user_ca_keys`, and `known_hosts` paths are now validated: values containing `/`, `\`, or `..` are rejected before substitution, so a crafted SSH username can no longer resolve a configured path outside its intended directory.
- `known_hosts` / `known_hosts_data`: if configured but the resolved data is empty (e.g. traversal is blocked, file missing/empty), `KnownHosts()` now returns an error instead of silently returning empty data, which previously caused the daemon to fall back to skipping upstream host key verification.

## Why
An SSH username like `../../../etc/some-shared-secret` could be substituted directly into a configured path template (e.g. `/keys/$DOWNSTREAM_USER`), letting one downstream user read another tenant's private key or known_hosts. If the traversed known_hosts path didn't resolve to real data, the daemon would treat that as "no known_hosts configured" and silently disable host key verification for that connection.

## Testing
- `go test -v -tags full ./plugin/yaml/...` (added `TestLoadFileOrDecodeRejectsPathTraversal`, `TestKnownHostsConfiguredButEmptyFails`, `TestKnownHostsNotConfiguredSucceeds`; all pass along with pre-existing tests)
- `go build -tags full ./plugin/yaml/...`
- `go vet -tags full ./plugin/yaml/...`

Note: `TestLoadConfig` fails on this branch and on `master` unmodified when run on Windows due to a pre-existing Unix-permission-bit check; unrelated to this change.