### PR TITLE
ci: pin lhstrh/action-repo-semver to a commit SHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Repo SemVer
-        uses: lhstrh/action-repo-semver@v1.2.1
+        uses: lhstrh/action-repo-semver@23839f38b149db8715f21dbd38e6dde122817222 # v1.2.1
         id: repo-semver
         with:
           bump: patch


### PR DESCRIPTION
## What
Pins `lhstrh/action-repo-semver` in `.github/workflows/release.yaml` to the commit SHA that `v1.2.1` currently resolves to, keeping the tag as a comment for readability.

## Why
The `draft` job in this workflow has `contents: write` and `packages: write` permissions and runs on every push to `master`. It referenced the action by a mutable tag (`@v1.2.1`) from an individual maintainer's account rather than an org, so a retagged release could execute arbitrary code with those permissions. Pinning to the exact commit removes that risk; the action's behavior is unchanged since the SHA is what `v1.2.1` currently points to.

## Testing
YAML change only - verified the workflow file still parses/renders correctly (no functional change to job logic, just the `uses:` ref).